### PR TITLE
fix: skip notifications when library detection fails with filtering enabled

### DIFF
--- a/jellyfinWebhook.js
+++ b/jellyfinWebhook.js
@@ -734,11 +734,25 @@ export async function handleJellyfinWebhook(req, res, client, pendingRequests) {
       }
       return;
     } else {
-      // No library detected - use default channel
-      libraryChannelId = process.env.JELLYFIN_CHANNEL_ID;
-      logger.warn(
-        `⚠️ Could not detect library. Using default channel: ${libraryChannelId}`
-      );
+      // No library detected
+      if (libraryKeys.length > 0) {
+        // User has configured library filtering but we can't detect library - skip notification
+        logger.info(
+          `🚫 Library filtering enabled but could not detect library for item. Skipping notification.`
+        );
+        if (res) {
+          return res
+            .status(200)
+            .send("OK: Notification skipped - library not detected.");
+        }
+        return;
+      } else {
+        // No library filtering configured - use default channel
+        libraryChannelId = process.env.JELLYFIN_CHANNEL_ID;
+        logger.warn(
+          `⚠️ Could not detect library. Using default channel: ${libraryChannelId}`
+        );
+      }
     }
 
     if (data.ItemType === "Movie") {


### PR DESCRIPTION
## Problem
User reported receiving notifications from adult media library despite configuring only Movies and Shows libraries for webhooks.

## Root Cause  
When library detection failed (`libraryId = null`), the system fell back to the default channel instead of respecting library filtering configuration.

## Solution
Modified webhook logic to skip notifications entirely when:
- Library filtering is enabled (user configured specific libraries)  
- Library detection fails (cannot determine which library the item belongs to)

## Changes
- Updated `jellyfinWebhook.js` lines 736-742
- Added check for `libraryKeys.length > 0` when library detection fails
- Skip notification instead of falling back to default channel when filtering is enabled

## Testing
- Verified syntax with `node -c`
- Tested logic with simulated scenarios
- Confirmed existing behavior preserved when no filtering configured

Fixes the issue where notifications were sent to default channel for items from undetected libraries when library filtering was enabled.