### PR TITLE
fix: look for static files relative to module directory

### DIFF
--- a/app.js
+++ b/app.js
@@ -1962,11 +1962,11 @@ function configureWebServer() {
     });
   });
 
-  app.use("/assets", express.static(path.join(process.cwd(), "assets")));
-  app.use(express.static(path.join(process.cwd(), "web")));
+  app.use("/assets", express.static(path.join(import.meta.dirname, "assets")));
+  app.use(express.static(path.join(import.meta.dirname, "web")));
 
   app.get("/", (req, res) => {
-    res.sendFile(path.join(process.cwd(), "web", "index.html"));
+    res.sendFile(path.join(import.meta.dirname, "web", "index.html"));
   });
 
   // --- JELLYFIN WEBHOOK ENDPOINT (no rate limiting for webhooks) ---


### PR DESCRIPTION
When running the application from a directory other than the application directory, Express file references break as they are relative to the current working directory, instead of the module directory. This PR fixes the issue by using the ESM built-in `import.meta.dirname`, which acts as the ES module replacement for CommonJS `__dirname` and is used to reference paths relative to the executed script.

It is documented here: https://nodejs.org/dist/latest/docs/api/esm.html#importmetadirname