### PR TITLE
Fix API call for Jellyseerr users

### DIFF
--- a/app.js
+++ b/app.js
@@ -1858,7 +1858,7 @@ function configureWebServer() {
         logger.info(
           "[JELLYSEERR USERS API] Fetching users from Jellyseerr (real-time)..."
         );
-        response = await axios.get(`${baseUrl}/user`, {
+        response = await axios.get(`${baseUrl}/user?take=` + Number.MAX_SAFE_INTEGER, {
           headers: { "X-Api-Key": apiKey },
           timeout: TIMEOUTS.JELLYSEERR_API,
         });


### PR DESCRIPTION
Utilizes the _take_ parameter for the Jellyseerr user API call which retrieves the entire list of Jellyseerr users instead of just the first 10.