### PR TITLE
fix: update Jellyfin webhook setup to use Generic destination

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -303,7 +303,7 @@
   "jellyfin_webhook": {
     "note": "Hinweis: Wenn du Anchorr in Docker ausführst, musst du möglicherweise localhost durch die IP-Adresse deines Servers ersetzen.",
     "plugin_install": "Falls du das Plugin nicht installiert hast, gehe zur Plugins-Seite in deinem Jellyfin Dashboard, suche nach Webhook, installiere es und starte den Server neu.",
-    "plugin_setup": "Nach dem Neustart gehe zu deinen Webhook-Plugin-Einstellungen und füge ein Discord-Ziel hinzu.",
+    "plugin_setup": "Nach dem Neustart gehe zu deinen Webhook-Plugin-Einstellungen und füge ein Generic-Ziel hinzu.",
     "step_server_url": "Vervollständige die Server-URL mit der Basis-URL deines Jellyfin-Servers.",
     "step_webhook_url": "Füge die zuvor angegebene URL in das Webhook-URL-Feld ein.",
     "step_status": "Status muss Aktiviert sein.",

--- a/locales/en.json
+++ b/locales/en.json
@@ -231,7 +231,7 @@
   "jellyfin_webhook": {
     "note": "If you're running Anchorr in Docker, you may need to replace localhost with your server's IP address.",
     "plugin_install": "If you don't have the plugin installed, access the Plugins page in your Jellyfin Dashboard, search for Webhook, install it and restart the server.",
-    "plugin_setup": "After the restart, access your Webhook plugin settings and Add Discord Destination.",
+    "plugin_setup": "After the restart, access your Webhook plugin settings and Add Generic Destination.",
     "step_server_url": "Complete the Server Url with your Jellyfin server's base URL.",
     "step_webhook_url": "Insert the previously specified URL in the Webhook Url field.",
     "step_status": "Status must be Enabled.",

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -209,7 +209,7 @@
   "jellyfin_webhook": {
     "note": "Om du kör Anchorr i Docker kan du behöva ersätta localhost med din servers IP-adress.",
     "plugin_install": "Om du inte har pluginet installerat, gå till Plugins-sidan i din Jellyfin Dashboard, sök efter Webhook, installera det och starta om servern.",
-    "plugin_setup": "Efter omstarten, gå till dina Webhook-plugininställningar och Lägg till Discord-destination.",
+    "plugin_setup": "Efter omstarten, gå till dina Webhook-plugininställningar och Lägg till Generic-destination.",
     "step_server_url": "Fyll i Server-URL med din Jellyfin-servers bas-URL.",
     "step_webhook_url": "Infoga den tidigare angivna URL:en i Webhook-URL-fältet.",
     "step_status": "Status måste vara Aktiverad.",

--- a/web/index.html
+++ b/web/index.html
@@ -658,7 +658,7 @@
                             >Copy Secret</button>
                           </div>
                           <p style="margin-top: 1.5rem;" data-i18n="jellyfin_webhook.plugin_install">If you don't have the plugin installed, access the <strong class="emphasis-mauve">Plugins page</strong> in your <strong class="emphasis-mauve">Jellyfin Dashboard</strong>, search for <strong class="emphasis-mauve">Webhook</strong>, install it and restart the server.</p>
-                          <p data-i18n="jellyfin_webhook.plugin_setup">After the reset, access your <strong class="emphasis-mauve">Webhook plugin settings</strong> and <strong class="emphasis-mauve">Add Discord Destination</strong>.</p>
+                          <p data-i18n="jellyfin_webhook.plugin_setup">After the restart, access your <strong class="emphasis-mauve">Webhook plugin settings</strong> and <strong class="emphasis-mauve">Add Generic Destination</strong>.</p>
                           <ol style="padding-left: 1.5rem; opacity: 0.9;">
                             <li data-i18n="jellyfin_webhook.step_server_url">Complete the <strong class="emphasis-mauve">Server Url</strong> with your Jellyfin server's base URL.</li>
                             <li data-i18n="jellyfin_webhook.step_webhook_url">Insert the previously specified URL in the <strong class="emphasis-mauve">Webhook Url</strong> field.</li>


### PR DESCRIPTION
Jellyfin's webhook plugin no longer supports a dedicated Discord destination type. Updates setup instructions to use Generic Destination instead.