### PR TITLE
fix: security hardening

### DIFF
--- a/app.js
+++ b/app.js
@@ -2314,9 +2314,18 @@ function configureWebServer() {
     legacyHeaders: false,
   });
 
-  // --- AUTH ENDPOINTS (no rate limiting for auth) ---
-  app.post("/api/auth/login", login);
-  app.post("/api/auth/register", register);
+  // Strict rate limiter for auth endpoints
+  const authLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 20,
+    message: { success: false, error: "Too many attempts, please try again later." },
+    standardHeaders: true,
+    legacyHeaders: false,
+  });
+
+  // --- AUTH ENDPOINTS ---
+  app.post("/api/auth/login", authLimiter, login);
+  app.post("/api/auth/register", authLimiter, register);
   app.post("/api/auth/logout", logout);
   app.get("/api/auth/check", checkAuth);
 

--- a/utils/auth.js
+++ b/utils/auth.js
@@ -116,14 +116,14 @@ export const login = async (req, res) => {
   }
 
   const token = jwt.sign({ id: user.id, username: user.username }, JWT_SECRET, {
-    expiresIn: "7d",
+    expiresIn: "24h",
   });
 
   res.cookie("auth_token", token, {
     httpOnly: true,
     secure: req.secure || req.headers["x-forwarded-proto"] === "https",
     sameSite: "strict",
-    maxAge: 7 * 24 * 60 * 60 * 1000, // 7 days
+    maxAge: 24 * 60 * 60 * 1000, // 24 hours
   });
 
   res.json({
@@ -152,7 +152,7 @@ export const register = async (req, res) => {
     });
   }
 
-  const salt = await bcrypt.genSalt(10);
+  const salt = await bcrypt.genSalt(12);
   const hashedPassword = await bcrypt.hash(password, salt);
 
   try {
@@ -162,13 +162,14 @@ export const register = async (req, res) => {
     const token = jwt.sign(
       { id: newUser.id, username: newUser.username },
       JWT_SECRET,
-      { expiresIn: "7d" }
+      { expiresIn: "24h" }
     );
 
     res.cookie("auth_token", token, {
       httpOnly: true,
       secure: req.secure || req.headers["x-forwarded-proto"] === "https",
-      maxAge: 7 * 24 * 60 * 60 * 1000, // 7 days
+      sameSite: "strict",
+      maxAge: 24 * 60 * 60 * 1000, // 24 hours
     });
 
     res.json({

--- a/utils/configFile.js
+++ b/utils/configFile.js
@@ -122,7 +122,7 @@ function migrateConfigIfNeeded() {
 
     // Write to new location
     fs.writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2), {
-      mode: 0o666,
+      mode: 0o600,
       encoding: "utf-8",
     });
 
@@ -179,7 +179,7 @@ export function writeConfig(config) {
 
     // Write with explicit permissions (sensitive fields are base64-encoded)
     fs.writeFileSync(CONFIG_PATH, JSON.stringify(encodeConfig(config), null, 2), {
-      mode: 0o666,
+      mode: 0o600,
       encoding: "utf-8",
     });
 


### PR DESCRIPTION
- Rate limiting on login/register (20 req / 15min)
- JWT session reduced from 7 days to 24 hours
- Missing `sameSite: strict` added to register cookie
- Bcrypt salt rounds increased from 10 to 12
- config.json file permissions tightened from `0o666` to `0o600`