### PR TITLE
fix: error visibility and silent failure improvements

### DIFF
--- a/api/tmdb.js
+++ b/api/tmdb.js
@@ -180,7 +180,7 @@ export async function tmdbGetRandomMedia(apiKey) {
         results = await getDiscoverNicheMedia(apiKey);
       }
     } catch (err) {
-      // Strategy failed, fallback below
+      logger.warn(`TMDB strategy "${strategy}" failed: ${err.message}`);
     }
 
     if (results.length === 0) {
@@ -218,6 +218,7 @@ export async function tmdbGetRandomMedia(apiKey) {
         details,
       };
     } catch (err) {
+      logger.warn(`Failed to fetch TMDB details for item ${randomItem?.id}: ${err.message}`);
       return randomItem;
     }
   } catch (error) {
@@ -235,6 +236,7 @@ async function getTrendingMedia(apiKey) {
     }
     return trendingResults;
   } catch (error) {
+    logger.warn(`getTrendingMedia failed: ${error.message}`);
     return [];
   }
 }

--- a/app.js
+++ b/app.js
@@ -698,7 +698,7 @@ function configureWebServer() {
             });
           } catch (error) {
             logger.error("Auto-start failed:", error.message);
-            res.status(200).json({
+            res.status(500).json({
               message: `Configuration saved, but bot failed to start: ${error.message}. Check credentials and try starting manually.`,
             });
           }

--- a/bot/botState.js
+++ b/bot/botState.js
@@ -48,6 +48,13 @@ export function loadPendingRequests() {
     }
     logger.info(`✅ Loaded ${pendingRequests.size} pending request(s) from disk`);
   } catch (err) {
-    logger.warn(`⚠️ Failed to load pending requests from disk: ${err.message}`);
+    logger.error(`Failed to load pending requests from disk: ${err.message}`);
+    try {
+      const corruptPath = PENDING_REQUESTS_PATH.replace(".json", `.corrupt.${Date.now()}.json`);
+      fs.renameSync(PENDING_REQUESTS_PATH, corruptPath);
+      logger.warn(`Corrupted pending requests file moved to ${path.basename(corruptPath)} — starting with empty state`);
+    } catch (_) {
+      // Cannot rename; original file stays in place
+    }
   }
 }

--- a/bot/botUtils.js
+++ b/bot/botUtils.js
@@ -152,12 +152,12 @@ export function checkRolePermission(member) {
   try {
     allowlist = process.env.ROLE_ALLOWLIST ? JSON.parse(process.env.ROLE_ALLOWLIST) : [];
   } catch (e) {
-    logger.warn("Invalid JSON in ROLE_ALLOWLIST, defaulting to empty list");
+    logger.error(`Invalid JSON in ROLE_ALLOWLIST — allowlist disabled, all users permitted: ${e.message}`);
   }
   try {
     blocklist = process.env.ROLE_BLOCKLIST ? JSON.parse(process.env.ROLE_BLOCKLIST) : [];
   } catch (e) {
-    logger.warn("Invalid JSON in ROLE_BLOCKLIST, defaulting to empty list");
+    logger.error(`Invalid JSON in ROLE_BLOCKLIST — blocklist disabled, no users blocked: ${e.message}`);
   }
 
   const userRoles = member.roles.cache.map((r) => r.id);

--- a/bot/interactions.js
+++ b/bot/interactions.js
@@ -36,7 +36,12 @@ async function handleSearchOrRequest(
   try {
     await interaction.deferReply({ ephemeral: isPrivateMode });
   } catch (err) {
-    logger.error(`Failed to defer reply: ${err.message}`);
+    logger.error(`Failed to defer reply for "${interaction.commandName}": ${err.message}`);
+    try {
+      await interaction.reply({ content: "⚠️ Something went wrong. Please try again.", ephemeral: true });
+    } catch (_) {
+      // Interaction token already invalid
+    }
     return;
   }
 

--- a/discord/commands.js
+++ b/discord/commands.js
@@ -91,16 +91,13 @@ export async function registerCommands(rest, botId, guildId, logger) {
     } catch (globalErr) {
       // Only attempt guild-specific fallback if guildId is provided
       if (!guildId) {
-        logger.warn(
-          `⚠️ Global command registration failed. GUILD_ID is not configured in config.json.`
+        logger.error(
+          `Global command registration failed: ${globalErr.message} — slash commands may not appear in Discord.`
         );
         logger.warn(
-          `Commands will be available globally once Discord syncs them (can take up to 1 hour).`
+          `To fix: add your server ID as GUILD_ID in config.json for immediate guild-specific registration.`
         );
-        logger.warn(
-          `To enable faster command registration for this server, add your server ID as GUILD_ID in config.json`
-        );
-        return; // Allow bot to continue, commands will work eventually
+        return;
       }
 
       logger.warn(

--- a/routes/logRoutes.js
+++ b/routes/logRoutes.js
@@ -65,7 +65,7 @@ router.get("/logs/error", authenticateToken, (req, res) => {
       errorLogPath = path.join(logsDir, errorFiles[0]);
     }
   } catch (e) {
-    // Fallback to default path
+    logger.warn(`Failed to enumerate log directory for error logs: ${e.message} — using default path`);
   }
 
   const { entries, truncated } = parseLogFile(errorLogPath);
@@ -92,7 +92,7 @@ router.get("/logs/all", authenticateToken, (req, res) => {
       combinedLogPath = path.join(logsDir, combinedFiles[0]);
     }
   } catch (e) {
-    // Fallback to default path
+    logger.warn(`Failed to enumerate log directory for combined logs: ${e.message} — using default path`);
   }
 
   const { entries, truncated } = parseLogFile(combinedLogPath);

--- a/utils/configFile.js
+++ b/utils/configFile.js
@@ -57,7 +57,7 @@ const getNewConfigPath = () => {
       // /config is writable, use it
       return "/config/config.json";
     } catch (e) {
-      // /config exists but not writable, continue to next option
+      logger.warn(`/config exists but is not writable (${e.code || e.message}) — falling back to internal config path`);
     }
   }
 
@@ -318,7 +318,13 @@ export function loadConfigToEnv() {
     jellyseerrDisplayName: "seerrDisplayName",
   };
   const rawMappings = config.USER_MAPPINGS;
-  const mappings = typeof rawMappings === "string" ? JSON.parse(rawMappings) : rawMappings;
+  let mappings;
+  try {
+    mappings = typeof rawMappings === "string" ? JSON.parse(rawMappings) : rawMappings;
+  } catch (err) {
+    logger.error(`Failed to parse USER_MAPPINGS in config — skipping migration: ${err.message}`);
+    mappings = null;
+  }
   if (mappings && typeof mappings === "object") {
     let mappingsMigrated = false;
     for (const mapping of Object.values(mappings)) {


### PR DESCRIPTION
## Summary

- **configFile**: `USER_MAPPINGS` JSON.parse wrapped in try/catch — malformed value no longer crashes startup; `/config` write-test failure now logs the exact errno so Docker users know why the fallback path is used
- **botState**: pending-requests load failure escalated from `warn` to `error`; corrupt file renamed to timestamped backup before starting fresh (no more repeated parse failures on restart)
- **botUtils**: `ROLE_ALLOWLIST`/`ROLE_BLOCKLIST` parse failure escalated to `error` with explicit note that enforcement is disabled — previously a misconfigured allowlist silently granted access to all users
- **interactions**: on `deferReply()` failure, bot now attempts an ephemeral reply so users see an error message instead of Discord's generic "interaction failed"
- **tmdb**: `getTrendingMedia`, strategy fallback, and item-detail enrichment now log `warn` on failure — operators can see TMDB rate-limit/auth errors instead of guessing why the daily pick is broken
- **commands**: global slash command registration failure escalated to `error` with the actual Discord error message when no `GUILD_ID` is configured
- **app**: `/api/config` returns HTTP 500 (not 200) when bot auto-start fails — `response.ok` now correctly signals failure to the dashboard
- **logRoutes**: log dir enumeration failure now logs `warn` instead of falling back silently

> AI-assisted documentation. Code logic manually verified.