### PR TITLE
feat: translate dashboard toast messages through i18n system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.5.2] - 2026-04-17
+
+### 🐛 Fixed
+
+- **Config startup crash**: A corrupted or malformed `USER_MAPPINGS` value in `config.json` no longer crashes the app on startup — the migration step is now skipped with a clear error log instead
+- **Config volume detection**: When `/config` exists but is not writable, a warning is now logged showing the exact reason (`EACCES`, `EROFS`, etc.) so Docker users understand why the fallback path is used
+- **Bot start failure HTTP status**: The `/api/config` endpoint now returns HTTP 500 (instead of 200) when the bot fails to auto-start after config save, allowing the dashboard to correctly surface the error
+- **ROLE_ALLOWLIST / ROLE_BLOCKLIST parse failure**: A malformed role list in config now logs at `error` level (previously `warn`) with an explicit note that enforcement is disabled — avoids silently granting access to all users
+- **Discord command registration failure**: When global command registration fails and no `GUILD_ID` is set, the error is now logged at `error` level with the failure reason, making it clear that slash commands may not appear
+- **Pending requests corruption**: If the pending-requests state file on disk is unreadable, the corrupted file is renamed to a timestamped backup before starting fresh — prevents repeated parse failures on restart
+- **TMDB strategy failures**: Failed random-pick strategies, detail enrichment, and trending fetch now log at `warn` level instead of failing silently — operators can see when TMDB is returning errors (rate limit, bad key, etc.)
+- **Log route fallback**: When the log directory cannot be enumerated (e.g. permission issue), the fallback to the default log path is now logged as a warning instead of silently applied
+- **deferReply failure feedback**: When deferring a Discord interaction fails, the bot now attempts a direct ephemeral reply so the user sees an error message instead of Discord's generic "interaction failed" screen
+
+### 🌍 Internationalization
+
+- **Dashboard toast messages translated**: All previously hardcoded English status and error messages in the web dashboard are now routed through the i18n system. Affected messages include copy confirmations, mapping add/remove feedback, connection validation warnings, user lookup failures, auto-map/sync previews, bot control errors, and more — 22 strings in total
+- **New locale keys** added to all supported languages (en, de, sv) and the translation template: `errors.fetch_config`, `errors.autostart_check`, `errors.no_webhook_secret`, `errors.copy_url_failed`, `errors.jellyfin_url_required`, `errors.jellyfin_api_key_required`, `errors.mapping_refresh_failed`, `errors.discord_user_lookup_failed`, `errors.automap_preview_failed`, `errors.sync_preview_failed`, `errors.refresh_users_failed`, `errors.bot_control_failed`, `errors.remove_mapping_failed`, `errors.save_mappings_failed`, `errors.remove_mappings_failed`, `errors.language_load_failed`, `success.webhook_secret_copied`, `success.webhook_url_copied`, `user_mapping.mapping_removed`, `user_mapping.mapping_added`, `user_mapping.no_mappings_selected`, `user_mapping.select_users`
+
+---
+
 ## [1.5.0] - 2026-04-14
 
 ### ✨ Added

--- a/locales/de.json
+++ b/locales/de.json
@@ -366,7 +366,33 @@
     "loading_logs": "Fehler beim Laden der Logs",
     "bot_must_be_running": "Bot muss laufen, um Rollen zu laden",
     "no_roles_available": "Keine Rollen verfügbar",
-    "logout_failed": "Abmeldung fehlgeschlagen. Bitte erneut versuchen."
+    "logout_failed": "Abmeldung fehlgeschlagen. Bitte erneut versuchen.",
+    "language_load_failed": "UI-Sprache konnte nicht geladen werden. Einige Beschriftungen fehlen möglicherweise.",
+    "fetch_config": "Fehler beim Abrufen der Konfiguration.",
+    "autostart_check": "Warnung: Bot-Autostart konnte nicht geprüft werden. Wird trotzdem gespeichert.",
+    "no_webhook_secret": "Kein Webhook-Secret konfiguriert.",
+    "copy_url_failed": "URL kopieren fehlgeschlagen. Bitte manuell kopieren.",
+    "jellyfin_url_required": "Bitte zuerst Jellyfin-URL eingeben.",
+    "jellyfin_api_key_required": "Bitte zuerst Jellyfin-API-Key eingeben.",
+    "mapping_refresh_failed": "Zuordnungen gespeichert, aber Aktualisierung fehlgeschlagen. Bitte Seite neu laden.",
+    "discord_user_lookup_failed": "Discord-Nutzer konnte nicht gefunden werden.",
+    "automap_preview_failed": "Auto-Map-Vorschau konnte nicht abgerufen werden.",
+    "sync_preview_failed": "Sync-Vorschau konnte nicht abgerufen werden.",
+    "refresh_users_failed": "Nutzer konnten nicht aktualisiert werden. Verbindungen prüfen.",
+    "bot_control_failed": "Bot-Steuerung fehlgeschlagen.",
+    "remove_mapping_failed": "Zuordnung konnte nicht entfernt werden.",
+    "save_mappings_failed": "Zuordnungen konnten nicht gespeichert werden.",
+    "remove_mappings_failed": "Zuordnungen konnten nicht entfernt werden."
+  },
+  "success": {
+    "webhook_secret_copied": "Webhook-Secret in Zwischenablage kopiert!",
+    "webhook_url_copied": "Webhook-URL in Zwischenablage kopiert!"
+  },
+  "user_mapping": {
+    "mapping_removed": "Zuordnung erfolgreich entfernt!",
+    "mapping_added": "Zuordnung erfolgreich hinzugefügt!",
+    "no_mappings_selected": "Keine Zuordnungen ausgewählt.",
+    "select_users": "Bitte sowohl Discord- als auch Seerr-Nutzer auswählen."
   },
   "modals": {
     "start_bot_yes": "Ja, Bot starten",

--- a/locales/en.json
+++ b/locales/en.json
@@ -294,7 +294,33 @@
     "loading_logs": "Error loading logs",
     "bot_must_be_running": "Bot must be running to load roles",
     "no_roles_available": "No roles available",
-    "logout_failed": "Logout failed. Please try again."
+    "logout_failed": "Logout failed. Please try again.",
+    "language_load_failed": "UI language could not be loaded. Some labels may be missing.",
+    "fetch_config": "Error fetching configuration.",
+    "autostart_check": "Warning: Could not check bot autostart state. Saving anyway.",
+    "no_webhook_secret": "No webhook secret configured.",
+    "copy_url_failed": "Failed to copy URL. Please copy manually.",
+    "jellyfin_url_required": "Please enter Jellyfin URL first.",
+    "jellyfin_api_key_required": "Please enter Jellyfin API Key first.",
+    "mapping_refresh_failed": "Mappings updated, but failed to refresh the list. Please reload the page.",
+    "discord_user_lookup_failed": "Failed to look up Discord user.",
+    "automap_preview_failed": "Failed to fetch auto-map preview.",
+    "sync_preview_failed": "Failed to fetch sync preview.",
+    "refresh_users_failed": "Failed to refresh users. Check connections.",
+    "bot_control_failed": "Failed to control bot.",
+    "remove_mapping_failed": "Failed to remove mapping.",
+    "save_mappings_failed": "Failed to save mappings.",
+    "remove_mappings_failed": "Failed to remove mappings."
+  },
+  "success": {
+    "webhook_secret_copied": "Webhook secret copied to clipboard!",
+    "webhook_url_copied": "Webhook URL copied to clipboard!"
+  },
+  "user_mapping": {
+    "mapping_removed": "Mapping removed successfully!",
+    "mapping_added": "Mapping added successfully!",
+    "no_mappings_selected": "No mappings selected.",
+    "select_users": "Please select both a Discord user and a Seerr user."
   },
   "modals": {
     "start_bot_yes": "Yes, Start Bot",

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -294,7 +294,33 @@
     "loading_logs": "Fel vid laddning av loggar",
     "bot_must_be_running": "Boten måste köras för att ladda roller",
     "no_roles_available": "Inga roller tillgängliga",
-    "logout_failed": "Utloggning misslyckades. Försök igen."
+    "logout_failed": "Utloggning misslyckades. Försök igen.",
+    "language_load_failed": "UI-språk kunde inte laddas. Vissa etiketter kan saknas.",
+    "fetch_config": "Fel vid hämtning av konfigurationen.",
+    "autostart_check": "Varning: Kunde inte kontrollera bot-autostart. Sparar ändå.",
+    "no_webhook_secret": "Ingen webhook-hemlighet konfigurerad.",
+    "copy_url_failed": "Misslyckades att kopiera URL. Kopiera manuellt.",
+    "jellyfin_url_required": "Ange Jellyfin-URL först.",
+    "jellyfin_api_key_required": "Ange Jellyfin API-nyckel först.",
+    "mapping_refresh_failed": "Mappningar sparade, men misslyckades med att uppdatera listan. Ladda om sidan.",
+    "discord_user_lookup_failed": "Misslyckades att hitta Discord-användaren.",
+    "automap_preview_failed": "Misslyckades att hämta auto-map förhandsvisning.",
+    "sync_preview_failed": "Misslyckades att hämta synkförhandsvisning.",
+    "refresh_users_failed": "Misslyckades att uppdatera användare. Kontrollera anslutningarna.",
+    "bot_control_failed": "Misslyckades att styra boten.",
+    "remove_mapping_failed": "Misslyckades att ta bort mappning.",
+    "save_mappings_failed": "Misslyckades att spara mappningar.",
+    "remove_mappings_failed": "Misslyckades att ta bort mappningar."
+  },
+  "success": {
+    "webhook_secret_copied": "Webhook-hemlighet kopierad till urklipp!",
+    "webhook_url_copied": "Webhook-URL kopierad till urklipp!"
+  },
+  "user_mapping": {
+    "mapping_removed": "Mappning borttagen!",
+    "mapping_added": "Mappning tillagd!",
+    "no_mappings_selected": "Inga mappningar valda.",
+    "select_users": "Välj en Discord-användare och en Seerr-användare."
   },
   "modals": {
     "start_bot_yes": "Ja, starta bot",

--- a/locales/template.json
+++ b/locales/template.json
@@ -294,7 +294,33 @@
     "loading_logs": "",
     "bot_must_be_running": "",
     "no_roles_available": "",
-    "logout_failed": ""
+    "logout_failed": "",
+    "language_load_failed": "",
+    "fetch_config": "",
+    "autostart_check": "",
+    "no_webhook_secret": "",
+    "copy_url_failed": "",
+    "jellyfin_url_required": "",
+    "jellyfin_api_key_required": "",
+    "mapping_refresh_failed": "",
+    "discord_user_lookup_failed": "",
+    "automap_preview_failed": "",
+    "sync_preview_failed": "",
+    "refresh_users_failed": "",
+    "bot_control_failed": "",
+    "remove_mapping_failed": "",
+    "save_mappings_failed": "",
+    "remove_mappings_failed": ""
+  },
+  "success": {
+    "webhook_secret_copied": "",
+    "webhook_url_copied": ""
+  },
+  "user_mapping": {
+    "mapping_removed": "",
+    "mapping_added": "",
+    "no_mappings_selected": "",
+    "select_users": ""
   },
   "modals": {
     "start_bot_yes": "",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anchorr",
-  "version": "1.5.0",
+  "version": "1.5.2",
   "main": "app.js",
   "scripts": {
     "start": "node app.js",

--- a/web/script.js
+++ b/web/script.js
@@ -345,7 +345,7 @@ document.addEventListener("DOMContentLoaded", async () => {
       updateWebhookUrl();
     } catch (error) {
       console.error("[Anchorr] fetchConfig failed:", error);
-      showToast("Error fetching configuration.");
+      showToast(t('errors.fetch_config'));
     }
   }
 
@@ -708,7 +708,7 @@ document.addEventListener("DOMContentLoaded", async () => {
       }
     } catch (error) {
       console.error("Autostart check failed, proceeding with save:", error);
-      showToast("Warning: Could not check bot autostart state. Saving anyway.");
+      showToast(t('errors.autostart_check'));
       await saveConfig(config);
     }
   });
@@ -938,12 +938,12 @@ document.addEventListener("DOMContentLoaded", async () => {
   document.getElementById("copy-webhook-secret-btn").addEventListener("click", () => {
     const textToCopy = document.getElementById("WEBHOOK_SECRET")?.value || "";
     if (!textToCopy) {
-      showToast("No webhook secret configured.");
+      showToast(t('errors.no_webhook_secret'));
       return;
     }
     if (navigator.clipboard && navigator.clipboard.writeText) {
       navigator.clipboard.writeText(textToCopy)
-        .then(() => showToast("Webhook secret copied to clipboard!"))
+        .then(() => showToast(t('success.webhook_secret_copied')))
         .catch(() => fallbackCopyTextToClipboard(textToCopy));
     } else {
       fallbackCopyTextToClipboard(textToCopy);
@@ -959,7 +959,7 @@ document.addEventListener("DOMContentLoaded", async () => {
       navigator.clipboard
         .writeText(textToCopy)
         .then(() => {
-          showToast("Webhook URL copied to clipboard!");
+          showToast(t('success.webhook_url_copied'));
         })
         .catch(() => {
           // Fallback if clipboard API fails
@@ -992,12 +992,12 @@ document.addEventListener("DOMContentLoaded", async () => {
     try {
       const successful = document.execCommand("copy");
       if (successful) {
-        showToast("Webhook URL copied to clipboard!");
+        showToast(t('success.webhook_url_copied'));
       } else {
-        showToast("Failed to copy URL. Please copy manually.");
+        showToast(t('errors.copy_url_failed'));
       }
     } catch (err) {
-      showToast("Failed to copy URL. Please copy manually.");
+      showToast(t('errors.copy_url_failed'));
     }
 
     document.body.removeChild(textArea);
@@ -1367,12 +1367,12 @@ document.addEventListener("DOMContentLoaded", async () => {
       const apiKey = document.getElementById("JELLYFIN_API_KEY").value;
 
       if (!url || !url.trim()) {
-        showToast("Please enter Jellyfin URL first.");
+        showToast(t('errors.jellyfin_url_required'));
         return;
       }
 
       if (!apiKey || !apiKey.trim()) {
-        showToast("Please enter Jellyfin API Key first.");
+        showToast(t('errors.jellyfin_api_key_required'));
         return;
       }
 
@@ -2433,7 +2433,7 @@ document.addEventListener("DOMContentLoaded", async () => {
       displayMappings();
     } catch (error) {
       console.error("[MAPPINGS] Failed to reload mappings:", error);
-      showToast("Mappings updated, but failed to refresh the list. Please reload the page.");
+      showToast(t('errors.mapping_refresh_failed'));
     }
   }
 
@@ -2569,13 +2569,13 @@ document.addEventListener("DOMContentLoaded", async () => {
       const result = await response.json();
 
       if (result.success) {
-        showToast("Mapping removed successfully!");
+        showToast(t('user_mapping.mapping_removed'));
         await loadMappings();
       } else {
         showToast(`Error: ${result.message}`);
       }
     } catch (error) {
-      showToast("Failed to remove mapping.");
+      showToast(t('errors.remove_mapping_failed'));
     }
   };
 
@@ -2591,7 +2591,7 @@ document.addEventListener("DOMContentLoaded", async () => {
       const seerrUserId = seerrSelect.dataset.value;
 
       if (!discordUserId || !seerrUserId) {
-        showToast("Please select both a Discord user and a Seerr user.");
+        showToast(t('user_mapping.select_users'));
         return;
       }
 
@@ -2615,7 +2615,7 @@ document.addEventListener("DOMContentLoaded", async () => {
             return;
           }
         } catch (_err) {
-          showToast("Failed to look up Discord user.");
+          showToast(t('errors.discord_user_lookup_failed'));
           return;
         }
       }
@@ -2642,7 +2642,7 @@ document.addEventListener("DOMContentLoaded", async () => {
         const result = await response.json();
 
         if (result.success) {
-          showToast("Mapping added successfully!");
+          showToast(t('user_mapping.mapping_added'));
 
           // Reset Discord custom select
           delete discordSelect.dataset.value;
@@ -2747,7 +2747,7 @@ document.addEventListener("DOMContentLoaded", async () => {
         modal.style.display = "flex";
       } catch (err) {
         console.error("[AUTO-MAP] Preview fetch error:", err);
-        showToast("Failed to fetch auto-map preview.");
+        showToast(t('errors.automap_preview_failed'));
       } finally {
         autoMapSeerrBtn.disabled = false;
         autoMapSeerrBtn.innerHTML = originalHtml;
@@ -2784,7 +2784,7 @@ document.addEventListener("DOMContentLoaded", async () => {
       const selected = checked.map((cb) => candidates[parseInt(cb.dataset.index, 10)]).filter(Boolean);
 
       if (selected.length === 0) {
-        showToast("No mappings selected.");
+        showToast(t('user_mapping.no_mappings_selected'));
         return;
       }
 
@@ -2813,7 +2813,7 @@ document.addEventListener("DOMContentLoaded", async () => {
         }
       } catch (err) {
         console.error("[AUTO-MAP] Save error:", err);
-        showToast("Failed to save mappings.");
+        showToast(t('errors.save_mappings_failed'));
       } finally {
         autoMapSaveBtn.disabled = false;
         autoMapSaveBtn.innerHTML = '<i class="bi bi-check-circle"></i> Save Mappings';
@@ -2947,7 +2947,7 @@ document.addEventListener("DOMContentLoaded", async () => {
         syncSeerrModal.style.display = "flex";
       } catch (err) {
         console.error("[SYNC] Preview fetch error:", err);
-        showToast("Failed to fetch sync preview.");
+        showToast(t('errors.sync_preview_failed'));
       } finally {
         syncSeerrBtn.disabled = false;
         syncSeerrBtn.innerHTML = originalHtml;
@@ -2962,7 +2962,7 @@ document.addEventListener("DOMContentLoaded", async () => {
       const selected = checked.map((cb) => stale[parseInt(cb.dataset.index, 10)]).filter(Boolean);
 
       if (selected.length === 0) {
-        showToast("No mappings selected.");
+        showToast(t('user_mapping.no_mappings_selected'));
         return;
       }
 
@@ -2996,7 +2996,7 @@ document.addEventListener("DOMContentLoaded", async () => {
         }
       } catch (err) {
         console.error("[SYNC] Remove error:", err);
-        showToast("Failed to remove mappings.");
+        showToast(t('errors.remove_mappings_failed'));
       } finally {
         syncSeerrRemoveBtn.disabled = false;
         syncSeerrRemoveBtn.innerHTML = '<i class="bi bi-trash"></i> Remove Selected';
@@ -3077,7 +3077,7 @@ document.addEventListener("DOMContentLoaded", async () => {
         }
       } catch (error) {
         console.error("Refresh users error:", error);
-        showToast("Failed to refresh users. Check connections.");
+        showToast(t('errors.refresh_users_failed'));
       } finally {
         refreshAllUsersBtn.disabled = false;
         refreshAllUsersBtn.innerHTML = originalHtml;
@@ -3663,7 +3663,7 @@ document.addEventListener("DOMContentLoaded", async () => {
         }, 1000);
       }
     } catch (error) {
-      showToast(`Failed to control bot.`);
+      showToast(t('errors.bot_control_failed'));
       botControlBtnLogs.disabled = false;
     }
   });


### PR DESCRIPTION
## Summary

- **22 hardcoded English strings** in `web/script.js` replaced with `t()` calls — previously these showed in English regardless of the user's language setting
- **New locale keys** added to all four locale files (`en`, `de`, `sv`, `template`) under three new namespaces: `errors.*`, `success.*`, `user_mapping.*`

Affected messages cover: copy confirmations (webhook secret/URL), mapping add/remove feedback, connection validation warnings (Jellyfin URL/API key), user lookup failures, auto-map and sync preview failures, bot control errors, and user refresh failures.

**What's NOT included** (scoped out intentionally):
- Bot-side Discord messages (`bot/interactions.js`, `bot/embeds.js`, `jellyfinWebhook.js`) — these have never been i18n'd and require building a server-side translation layer from scratch
- Dynamic strings with server-generated content (e.g. `showToast(result.message)`) — these come from the backend and cannot be translated client-side without server changes

> AI-assisted documentation. Code logic manually verified.