### PR TITLE
fix(webhook): restore backdrop on single-episode notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.5.3] - 2026-04-20
+
+### 🐛 Fixed
+
+- **Missing backdrop image on single-episode Discord notifications**: When Jellyfin sent an episode webhook, the TMDB lookup used the episode's own TMDB ID (not the series'), which typically returned no data. The fallback then tried to load a backdrop from the episode item in Jellyfin — but episodes don't carry their own backdrop image, only the parent series does. The notification was rendered with a blank image. Episode notifications now fall back to the parent series' backdrop (`Items/{SeriesId}/Images/Backdrop`) when TMDB data isn't available, matching the visual consistency of movie and series notifications.
+
+---
+
 ## [1.5.2] - 2026-04-17
 
 ### 🐛 Fixed

--- a/jellyfinWebhook.js
+++ b/jellyfinWebhook.js
@@ -527,6 +527,11 @@ async function processAndSendNotification(
 
   const backdropPath = details ? findBestBackdrop(details) : null;
   // Episodes don't have their own backdrop in Jellyfin — fall back to the series.
+  if (ItemType === "Episode" && !SeriesId) {
+    logger.warn(
+      `Episode webhook missing SeriesId; backdrop fallback will use ItemId and likely 404. ItemId=${ItemId}, Name=${Name}`
+    );
+  }
   const fallbackBackdropItemId =
     ItemType === "Episode" && SeriesId ? SeriesId : ItemId;
   const backdrop = backdropPath

--- a/jellyfinWebhook.js
+++ b/jellyfinWebhook.js
@@ -526,9 +526,12 @@ async function processAndSendNotification(
   }
 
   const backdropPath = details ? findBestBackdrop(details) : null;
+  // Episodes don't have their own backdrop in Jellyfin — fall back to the series.
+  const fallbackBackdropItemId =
+    ItemType === "Episode" && SeriesId ? SeriesId : ItemId;
   const backdrop = backdropPath
     ? `https://image.tmdb.org/t/p/w1280${backdropPath}`
-    : buildJellyfinUrl(ServerUrl, `Items/${ItemId}/Images/Backdrop`);
+    : buildJellyfinUrl(ServerUrl, `Items/${fallbackBackdropItemId}/Images/Backdrop`);
   
   if (showBackdrop && isValidUrl(backdrop)) {
     embed.setImage(backdrop);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anchorr",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "main": "app.js",
   "scripts": {
     "start": "node app.js",


### PR DESCRIPTION
## Summary

Single-episode Discord notifications rendered without a backdrop image while movies, series, and the dashboard "Test Episodes" button worked fine. Reported by a user (see screenshot in the issue thread).

## Root cause

Two issues compounded in `jellyfinWebhook.js`:

1. **TMDB lookup returns nothing for real episodes.** Jellyfin's webhook payload for an episode sets `Provider_tmdb` to the **episode's** TMDB id, not the series'. The code calls `/tv/{episodeTmdbId}` which typically 404s, so `details` is `null` and no TMDB backdrop is resolved.
2. **Jellyfin fallback pointed at the wrong item.** The fallback URL was `Items/{ItemId}/Images/Backdrop`, where `ItemId` is the episode's id. Episodes in Jellyfin have no backdrop image — only the parent series does — so the embed ended up with a broken/blank image.

The "Test Episodes" button in the dashboard works because `app.js` hardcodes `Provider_tmdb: \"1396\"` (the Breaking Bad **series** id), so TMDB returns a valid backdrop and the fallback is never hit.

## Fix

For Episode notifications, the Jellyfin backdrop fallback now uses `SeriesId` instead of the episode's `ItemId`. Movies, series, and seasons are unaffected. If `SeriesId` is absent for some reason, it falls back to the previous behaviour so nothing regresses.

## Changes

- `jellyfinWebhook.js`: episode backdrop fallback uses `SeriesId`
- `package.json`: `1.5.2` → `1.5.3`
- `CHANGELOG.md`: 1.5.3 entry

## Verification

- Manual: static review of the affected code path against Jellyfin webhook field semantics and the existing `Test Episodes` / `Batch Episodes` flows in `app.js`.
- Syntax: `node --check jellyfinWebhook.js` passes.
- PR description drafted with AI assistance; code change reviewed manually before commit.