### PR TITLE
fix(deps): pin follow-redirects to ^1.16.0 (GHSA-r4q5-vmmm-2653)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.5.3] - 2026-04-20
 
+### 🔒 Security
+
+- **Pin `follow-redirects` to `^1.16.0`** (GHSA-r4q5-vmmm-2653): Versions `<= 1.15.11` only strip `authorization`, `proxy-authorization`, and `cookie` headers on cross-domain redirects, so custom auth headers (`X-Api-Key` for Jellyseerr, `X-MediaBrowser-Token` for Jellyfin) would have leaked to the redirect target. Exploitability in Anchorr is low — the affected hosts are user-configured self-hosted services — but the patched version strips custom auth headers on cross-domain redirect by default. Pinned via `overrides` in `package.json` since `follow-redirects` is a transitive dependency of `axios`.
+
 ### 🐛 Fixed
 
 - **Missing backdrop image on single-episode Discord notifications**: When Jellyfin sent an episode webhook, the TMDB lookup used the episode's own TMDB ID (not the series'), which typically returned no data. The fallback then tried to load a backdrop from the episode item in Jellyfin — but episodes don't carry their own backdrop image, only the parent series does. The notification was rendered with a blank image. Episode notifications now fall back to the parent series' backdrop (`Items/{SeriesId}/Images/Backdrop`) when TMDB data isn't available, matching the visual consistency of movie and series notifications.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "anchorr",
-  "version": "1.5.0",
+  "version": "1.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "anchorr",
-      "version": "1.5.0",
+      "version": "1.5.3",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.12.2",
@@ -872,9 +872,9 @@
       "license": "MIT"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",

--- a/package.json
+++ b/package.json
@@ -27,5 +27,8 @@
     "winston": "^3.11.0",
     "winston-daily-rotate-file": "^4.7.1",
     "ws": "^8.18.0"
+  },
+  "overrides": {
+    "follow-redirects": "^1.16.0"
   }
 }


### PR DESCRIPTION
## Summary

Resolves Dependabot alert #1 (GHSA-r4q5-vmmm-2653, medium).

`follow-redirects <= 1.15.11` only strips `authorization`, `proxy-authorization`, and `cookie` headers on cross-domain redirects. Anchorr sends custom auth headers via axios:

- `X-Api-Key` for Jellyseerr (`api/seerr.js`, `routes/seerrRoutes.js`)
- `X-MediaBrowser-Token` for Jellyfin (`api/jellyfin.js`, `routes/jellyfinRoutes.js`)

On a cross-domain redirect, these would have been forwarded to the redirect target. Real-world exploitability in Anchorr is low since affected hosts are user-configured self-hosted services, but the patched `follow-redirects 1.16.0` strips custom auth headers on cross-domain redirect by default.

## Changes

- `package.json`: added `overrides` entry pinning `follow-redirects` to `^1.16.0` (transitive via axios)
- `package-lock.json`: regenerated via `npm install --package-lock-only`
- `CHANGELOG.md`: entry under 1.5.3 `🔒 Security`

## Verification

- `npm audit` reports 0 vulnerabilities after the bump
- `follow-redirects` resolved version in lockfile is `1.16.0`
- PR description drafted with AI assistance; code change reviewed manually.