### PR TITLE
ci: run audit on PRs, skip image build for PR events

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -7,6 +7,10 @@ on:
       - dev
     tags:
       - 'v*'
+  pull_request:
+    branches:
+      - main
+      - dev
   workflow_dispatch:
 
 jobs:
@@ -32,6 +36,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: audit
+    if: github.event_name != 'pull_request'
 
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

- **`docker-build.yml`**: added `pull_request` trigger for `main` and `dev` so the `audit` job (`npm audit --audit-level=high`) runs on every PR against those branches
- **`build` job guarded**: added `if: github.event_name != 'pull_request'` so PR branches never push Docker images to Docker Hub or GHCR — images are still built and pushed on `push` to `main`/`dev`, on `v*` tags, and via `workflow_dispatch`
- Enables `audit` as a required status check for branch protection on `main`

> AI-assisted documentation. Code logic manually verified.