### PR TITLE
fix(dedup): Sonarr/Radarr upgrades no longer trigger duplicate notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,5 @@ coverage/
 TODO.md
 SRP_ANALYSIS.md
 ToDo_v2.md
-docs/glossary.md
+docs/
+config/dedup-*.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.5.4] - 2026-04-26
+
+### 🐛 Fixed
+
+- **Sonarr/Radarr quality upgrades no longer trigger duplicate "new content" Discord notifications.** When Sonarr or Radarr replaced an existing file with a higher-quality release, Jellyfin assigned a new internal `ItemId` to the re-imported file. Anchorr's dedup keyed off that ItemId and treated the upgrade as a brand-new item. The dedup layer now keys items by a stable identity (TMDB ID + season/episode for shows, TMDB ID for movies) that survives file replacement. Dedup window extended to 7 days to cover typical upgrade cycles.
+- **Dedup state survives container restarts.** Previously the in-memory dedup maps were wiped on every restart, so the next poll/WebSocket reconnect would re-notify everything in the recently-added window. State is now persisted to `config/dedup-*.json` and reloaded on startup, with expired entries dropped automatically.
+
+---
+
 ## [1.5.3] - 2026-04-20
 
 ### 🔒 Security

--- a/jellyfin/libraryResolver.js
+++ b/jellyfin/libraryResolver.js
@@ -187,7 +187,9 @@ export function buildIdentityKey(item) {
  */
 export class ItemDeduplicator {
   constructor() {
-    this.store = new PersistentMap("seen-items", SEEN_THRESHOLD_MS);
+    this.store = new PersistentMap("seen-items", SEEN_THRESHOLD_MS, {
+      validateValue: (v) => v === true,
+    });
   }
 
   /**

--- a/jellyfin/libraryResolver.js
+++ b/jellyfin/libraryResolver.js
@@ -105,6 +105,78 @@ export function getLibraryAnimeFlag(configLibraryId, libraryChannels) {
 }
 
 /**
+ * Build a stable identity key for an item that survives Sonarr/Radarr upgrades.
+ *
+ * File replacements give the item a new Jellyfin ItemId, so dedup by ItemId
+ * misfires. This key is keyed off content identity (TMDB/SeriesId + S/E)
+ * instead of file identity.
+ *
+ * Accepts both:
+ *   - Webhook payload shape: { ItemType, Provider_tmdb, SeriesId, Name, Year,
+ *     SeasonNumber, EpisodeNumber, IndexNumber, ParentIndexNumber, ItemId }
+ *   - Jellyfin API shape:    { Type, ProviderIds: { Tmdb }, SeriesId, Name,
+ *     ProductionYear, IndexNumber, ParentIndexNumber, Id }
+ *
+ * Falls back to `id:{ItemId}` if no stable identity is derivable — that
+ * preserves legacy behavior for unidentified items rather than silently
+ * grouping them.
+ */
+export function buildIdentityKey(item) {
+  if (!item) return null;
+
+  const type = item.ItemType || item.Type;
+  const tmdb = item.Provider_tmdb || item.ProviderIds?.Tmdb;
+  const seriesId = item.SeriesId;
+  const seasonNum = item.SeasonNumber ?? item.ParentIndexNumber;
+  const episodeNum = item.EpisodeNumber ?? item.IndexNumber;
+  const name = item.Name;
+  const year = item.Year || item.ProductionYear;
+  const itemId = item.ItemId || item.Id;
+
+  switch (type) {
+    case "Movie":
+      if (tmdb) return `movie:tmdb:${tmdb}`;
+      if (name) return `movie:name:${name}:${year ?? "?"}`;
+      return itemId ? `id:${itemId}` : null;
+
+    case "Series":
+      if (tmdb) return `series:tmdb:${tmdb}`;
+      if (seriesId) return `series:id:${seriesId}`;
+      if (name) return `series:name:${name}`;
+      return itemId ? `id:${itemId}` : null;
+
+    case "Season": {
+      const seriesKey = tmdb
+        ? `tmdb:${tmdb}`
+        : seriesId
+        ? `id:${seriesId}`
+        : name
+        ? `name:${name}`
+        : null;
+      if (seriesKey && seasonNum != null) return `series:${seriesKey}:s${seasonNum}`;
+      return itemId ? `id:${itemId}` : null;
+    }
+
+    case "Episode": {
+      const seriesKey = tmdb
+        ? `tmdb:${tmdb}`
+        : seriesId
+        ? `id:${seriesId}`
+        : item.SeriesName
+        ? `name:${item.SeriesName}`
+        : null;
+      if (seriesKey && seasonNum != null && episodeNum != null) {
+        return `series:${seriesKey}:s${seasonNum}e${episodeNum}`;
+      }
+      return itemId ? `id:${itemId}` : null;
+    }
+
+    default:
+      return itemId ? `id:${itemId}` : null;
+  }
+}
+
+/**
  * Shared in-memory deduplication store for seen Jellyfin item IDs.
  * Shared between the poller and WebSocket client so that an item
  * detected by both within 24 hours is only notified once.

--- a/jellyfin/libraryResolver.js
+++ b/jellyfin/libraryResolver.js
@@ -1,8 +1,8 @@
 import * as jellyfinApi from "../api/jellyfin.js";
 import logger from "../utils/logger.js";
 
-const SEEN_THRESHOLD_MS = 24 * 60 * 60 * 1000; // 24 hours
-const CLEANUP_AGE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+const SEEN_THRESHOLD_MS = 7 * 24 * 60 * 60 * 1000; // 7 days — survive Sonarr/Radarr upgrade cycles
+const CLEANUP_AGE_MS = 14 * 24 * 60 * 60 * 1000; // 14 days
 
 /**
  * Fetches all libraries from Jellyfin and returns the library array,
@@ -188,15 +188,31 @@ export class ItemDeduplicator {
 
   /**
    * Returns true if the item was seen recently (within SEEN_THRESHOLD_MS).
-   * If not seen recently, records it and returns false.
+   * Accepts either an item object (poller/WS pass the raw Jellyfin item)
+   * or a pre-built identity key string.
+   *
+   * If no stable key can be derived, falls back to logging a warning and
+   * returning false so we never silently skip dedup entirely.
    */
-  checkAndRecord(itemId) {
-    const now = Date.now();
-    const lastSeen = this.seenItems.get(itemId);
-    if (lastSeen && now - lastSeen < SEEN_THRESHOLD_MS) {
-      return true; // already seen
+  checkAndRecord(itemOrKey) {
+    let key;
+    if (typeof itemOrKey === "string") {
+      key = itemOrKey;
+    } else {
+      key = buildIdentityKey(itemOrKey);
+      if (!key) {
+        logger.warn(
+          "ItemDeduplicator.checkAndRecord called with un-keyable input; treating as not-seen"
+        );
+        return false;
+      }
     }
-    this.seenItems.set(itemId, now);
+    const now = Date.now();
+    const lastSeen = this.seenItems.get(key);
+    if (lastSeen && now - lastSeen < SEEN_THRESHOLD_MS) {
+      return true;
+    }
+    this.seenItems.set(key, now);
     return false;
   }
 

--- a/jellyfin/libraryResolver.js
+++ b/jellyfin/libraryResolver.js
@@ -205,8 +205,10 @@ export class ItemDeduplicator {
     } else {
       key = buildIdentityKey(itemOrKey);
       if (!key) {
+        const type = itemOrKey?.Type || itemOrKey?.ItemType;
+        const name = itemOrKey?.Name;
         logger.warn(
-          "ItemDeduplicator.checkAndRecord called with un-keyable input; treating as not-seen"
+          `ItemDeduplicator.checkAndRecord: un-keyable input (Type=${type}, Name=${name}); dedup bypassed for this item`
         );
         return false;
       }

--- a/jellyfin/libraryResolver.js
+++ b/jellyfin/libraryResolver.js
@@ -1,8 +1,8 @@
 import * as jellyfinApi from "../api/jellyfin.js";
 import logger from "../utils/logger.js";
+import { PersistentMap } from "../utils/persistentMap.js";
 
 const SEEN_THRESHOLD_MS = 7 * 24 * 60 * 60 * 1000; // 7 days — survive Sonarr/Radarr upgrade cycles
-const CLEANUP_AGE_MS = 14 * 24 * 60 * 60 * 1000; // 14 days
 
 /**
  * Fetches all libraries from Jellyfin and returns the library array,
@@ -177,13 +177,17 @@ export function buildIdentityKey(item) {
 }
 
 /**
- * Shared in-memory deduplication store for seen Jellyfin item IDs.
+ * Persistent deduplication store for seen Jellyfin items.
  * Shared between the poller and WebSocket client so that an item
- * detected by both within 24 hours is only notified once.
+ * detected by both within SEEN_THRESHOLD_MS is only notified once.
+ *
+ * State is persisted to disk so it survives container restarts —
+ * otherwise a restart would re-notify everything in the recently-added
+ * window via the next poll/WS reconnect.
  */
 export class ItemDeduplicator {
   constructor() {
-    this.seenItems = new Map(); // itemId → timestamp
+    this.store = new PersistentMap("seen-items", SEEN_THRESHOLD_MS);
   }
 
   /**
@@ -207,21 +211,13 @@ export class ItemDeduplicator {
         return false;
       }
     }
-    const now = Date.now();
-    const lastSeen = this.seenItems.get(key);
-    if (lastSeen && now - lastSeen < SEEN_THRESHOLD_MS) {
-      return true;
-    }
-    this.seenItems.set(key, now);
+    if (this.store.has(key)) return true;
+    this.store.set(key, true);
     return false;
   }
 
-  /** Remove entries older than 7 days to prevent unbounded growth. */
   cleanup() {
-    const cutoff = Date.now() - CLEANUP_AGE_MS;
-    for (const [id, ts] of this.seenItems) {
-      if (ts < cutoff) this.seenItems.delete(id);
-    }
+    this.store.cleanup();
   }
 }
 

--- a/jellyfinPoller.js
+++ b/jellyfinPoller.js
@@ -159,9 +159,9 @@ class JellyfinPoller {
           continue;
         }
 
-        // Deduplication
-        if (deduplicator.checkAndRecord(itemId)) {
-          logger.info(`⏭️ Skipping ${itemType} "${item.Name}" - already notified recently`);
+        // Deduplication — pass the item so identity key survives Sonarr/Radarr upgrades
+        if (deduplicator.checkAndRecord(item)) {
+          logger.info(`⏭️ Skipping ${itemType} "${item.Name}" - already notified recently (identity dedup)`);
           continue;
         }
 

--- a/jellyfinPoller.js
+++ b/jellyfinPoller.js
@@ -159,7 +159,6 @@ class JellyfinPoller {
           continue;
         }
 
-        // Deduplication — pass the item so identity key survives Sonarr/Radarr upgrades
         if (deduplicator.checkAndRecord(item)) {
           logger.info(`⏭️ Skipping ${itemType} "${item.Name}" - already notified recently (identity dedup)`);
           continue;

--- a/jellyfinWebSocket.js
+++ b/jellyfinWebSocket.js
@@ -279,22 +279,19 @@ export class JellyfinWebSocketClient {
     libraryChannels,
     defaultChannelId
   ) {
-    // Deduplication
-    if (deduplicator.checkAndRecord(itemId)) {
-      const lastSeen = deduplicator.seenItems.get(itemId);
-      logger.info(
-        `⏭️ Skipping item ${itemId} - already notified recently (${Math.round(
-          (Date.now() - lastSeen) / 60000
-        )} minutes ago)`
-      );
-      return;
-    }
-
     logger.info(`🔍 Processing newly added item: ${itemId}`);
 
     const item = await jellyfinApi.fetchItemDetails(itemId, apiKey, baseUrl);
     if (!item) {
       logger.warn(`Failed to fetch details for item ${itemId}`);
+      return;
+    }
+
+    // Deduplication after fetch — identity key needs item type, providers, S/E
+    if (deduplicator.checkAndRecord(item)) {
+      logger.info(
+        `⏭️ Skipping item ${itemId} ("${item.Name}") - already notified recently (identity dedup)`
+      );
       return;
     }
 

--- a/jellyfinWebhook.js
+++ b/jellyfinWebhook.js
@@ -26,6 +26,18 @@ const sentNotifications = new PersistentMap(
   "sent-notifications",
   7 * 24 * 60 * 60 * 1000 // 7 days — survive Sonarr/Radarr upgrade cycles
 );
+
+// Sweep stale "in-progress" markers (level: -1) from a previous run. Their
+// associated debouncer is gone after restart, so the marker would otherwise
+// block notifications for that series until its 5-min TTL expires.
+const staleMarkers = sentNotifications.prune(
+  (_key, value) => value?.level === -1
+);
+if (staleMarkers > 0) {
+  logger.info(
+    `[DEDUP] Cleared ${staleMarkers} stale in-progress markers from previous run`
+  );
+}
 const episodeMessages = new Map(); // Track Discord messages for editing: SeriesId -> { messageId, channelId }
 const creatingDebouncers = new Set(); // Prevent race condition: track SeriesIds currently creating debouncers
 

--- a/jellyfinWebhook.js
+++ b/jellyfinWebhook.js
@@ -15,6 +15,7 @@ import {
   getLibraryChannels,
   resolveTargetChannel,
   getLibraryAnimeFlag,
+  buildIdentityKey,
 } from "./jellyfin/libraryResolver.js";
 
 const debouncedSenders = new Map();
@@ -48,10 +49,11 @@ const libraryCache = {
 
 // Cleanup configuration
 const CLEANUP_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
-const CLEANUP_THRESHOLD_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+const CLEANUP_THRESHOLD_MS = 14 * 24 * 60 * 60 * 1000; // 14 days — periodic cleanup of stale debouncers
 const DEFAULT_DEBOUNCE_MS = 60000; // 60 seconds
 const NEW_SERIES_DEBOUNCE_MS = 120000; // 2 minutes - longer debounce for episodes/seasons of new series
 const SEASON_NOTIFICATION_DELAY_MS = 3 * 60 * 1000; // 3 minutes - allow season notifications after this delay
+const SENT_NOTIFICATION_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days — survive Sonarr/Radarr upgrade cycles
 
 // Periodic cleanup for old debouncer entries and API cache (prevent memory leaks on long-running servers)
 setInterval(() => {
@@ -938,11 +940,12 @@ export async function handleJellyfinWebhook(req, res, client, pendingRequests, o
     if (data.ItemType === "Movie") {
       const { ItemId } = data;
       const isTestMovie = ItemId && ItemId.startsWith("test-");
+      const movieKey = isTestMovie ? `test:${ItemId}` : (buildIdentityKey(data) || `id:${ItemId}`);
 
-      // Check if we already sent a notification for this movie
-      if (sentNotifications.has(ItemId)) {
-        logger.debug(
-          `Duplicate movie notification detected for: ${data.Name} (${ItemId}). Skipping.`
+      // Check if we already sent a notification for this movie (identity-keyed, survives upgrades)
+      if (sentNotifications.has(movieKey)) {
+        logger.info(
+          `[DEDUP] Duplicate movie notification suppressed for "${data.Name}" (key: ${movieKey})`
         );
         if (res) {
           return res
@@ -966,15 +969,15 @@ export async function handleJellyfinWebhook(req, res, client, pendingRequests, o
         isAnimeLibrary
       );
 
-      // Mark this movie as notified
+      // Mark this movie as notified — 7d TTL covers typical Sonarr/Radarr upgrade window
       const cleanupTimer = setTimeout(() => {
-        sentNotifications.delete(ItemId);
+        sentNotifications.delete(movieKey);
         logger.debug(
-          `Cleaned up movie notification state for ItemId: ${ItemId}`
+          `Cleaned up movie notification state for key: ${movieKey}`
         );
-      }, 24 * 60 * 60 * 1000); // 24 hours
+      }, SENT_NOTIFICATION_TTL_MS);
 
-      sentNotifications.set(ItemId, {
+      sentNotifications.set(movieKey, {
         level: 0, // Movies don't have hierarchy levels
         cleanupTimer: cleanupTimer,
       });
@@ -991,6 +994,18 @@ export async function handleJellyfinWebhook(req, res, client, pendingRequests, o
       // For Series type, SeriesId is undefined, so use ItemId instead
       const SeriesId =
         data.SeriesId || (data.ItemType === "Series" ? data.ItemId : null);
+
+      // Build an upgrade-stable series-level identity key for sentNotifications.
+      // Episodes/Seasons fold into the series-level entry by reusing the Series identity.
+      const seriesIdentityInput = {
+        ItemType: "Series",
+        Provider_tmdb: data.Provider_tmdb,
+        SeriesId: SeriesId,
+        Name: data.SeriesName || (data.ItemType === "Series" ? data.Name : null),
+        ItemId: SeriesId,
+      };
+      const seriesKey = buildIdentityKey(seriesIdentityInput) || `id:${SeriesId}`;
+      logger.debug(`[DEDUP] Series identity key for "${data.Name}": ${seriesKey} (raw SeriesId: ${SeriesId})`);
       
       // Initialize variables outside the if block so they're accessible later
       let sentNotificationData = null;
@@ -1003,7 +1018,7 @@ export async function handleJellyfinWebhook(req, res, client, pendingRequests, o
       const skipDuplicateCheck = data.ItemId && data.ItemId.startsWith("test-");
       
       if (!skipDuplicateCheck) {
-        sentNotificationData = sentNotifications.get(SeriesId);
+        sentNotificationData = sentNotifications.get(seriesKey);
         sentLevel = sentNotificationData ? sentNotificationData.level : 0;
         sentTimestamp = sentNotificationData
           ? sentNotificationData.timestamp
@@ -1023,7 +1038,7 @@ export async function handleJellyfinWebhook(req, res, client, pendingRequests, o
       // If sentLevel === -1 (temporary marker), it means notification is being processed
       // Only block if there's no active debouncer (which would allow batching)
       if (sentLevel === -1) {
-        if (!debouncedSenders.has(SeriesId)) {
+        if (!debouncedSenders.has(seriesKey)) {
           shouldBlock = true;
           logger.debug(`[BLOCKED] Notification for ${data.ItemType} "${data.Name}" blocked: already processing this series with no active debouncer (sentLevel: ${sentLevel})`);
         } else {
@@ -1125,8 +1140,8 @@ export async function handleJellyfinWebhook(req, res, client, pendingRequests, o
       // This prevents duplicate notifications from delayed webhooks
       // ALSO: Check if we're already creating a debouncer to prevent race condition
       if (
-        !debouncedSenders.has(SeriesId) &&
-        !creatingDebouncers.has(SeriesId)
+        !debouncedSenders.has(seriesKey) &&
+        !creatingDebouncers.has(seriesKey)
       ) {
         // Check if we already sent a notification for this series
         if (sentLevel > 0) {
@@ -1144,7 +1159,7 @@ export async function handleJellyfinWebhook(req, res, client, pendingRequests, o
         }
 
         // Mark this SeriesId as currently creating a debouncer
-        creatingDebouncers.add(SeriesId);
+        creatingDebouncers.add(seriesKey);
 
         // Check if this is a batch test notification
         const isBatchTest = data.ItemId && data.ItemId.startsWith("batch-");
@@ -1193,8 +1208,8 @@ export async function handleJellyfinWebhook(req, res, client, pendingRequests, o
               const levelSent = getItemLevel(latestData.ItemType);
 
               // Clear any existing cleanup timer (from temporary marker)
-              if (sentNotifications.has(SeriesId)) {
-                const existingNotification = sentNotifications.get(SeriesId);
+              if (sentNotifications.has(seriesKey)) {
+                const existingNotification = sentNotifications.get(seriesKey);
                 if (existingNotification.cleanupTimer) {
                   clearTimeout(existingNotification.cleanupTimer);
                 }
@@ -1203,13 +1218,13 @@ export async function handleJellyfinWebhook(req, res, client, pendingRequests, o
               // Set a cleanup timer for the 'sent' notification state
               // Use a longer duration to prevent duplicate notifications from delayed webhooks
               const cleanupTimer = setTimeout(() => {
-                sentNotifications.delete(SeriesId);
+                sentNotifications.delete(seriesKey);
                 logger.debug(
                   `Cleaned up sent notification state for SeriesId: ${SeriesId}`
                 );
-              }, 2 * 60 * 60 * 1000); // 2 hours instead of 24 hours - enough to block duplicates but not too long
+              }, SENT_NOTIFICATION_TTL_MS);
 
-              sentNotifications.set(SeriesId, {
+              sentNotifications.set(seriesKey, {
                 level: levelSent,
                 timestamp: Date.now(),
                 cleanupTimer: cleanupTimer,
@@ -1219,28 +1234,28 @@ export async function handleJellyfinWebhook(req, res, client, pendingRequests, o
               );
 
               // The debounced function has fired, we can remove it.
-              debouncedSenders.delete(SeriesId);
-              creatingDebouncers.delete(SeriesId); // Also cleanup from creatingDebouncers
+              debouncedSenders.delete(seriesKey);
+              creatingDebouncers.delete(seriesKey); // Also cleanup from creatingDebouncers
             } catch (error) {
               logger.error(
                 `Error in debounced notification for series ${SeriesId}:`,
                 error
               );
               // Cleanup all maps on error so future webhooks for this series are not blocked
-              debouncedSenders.delete(SeriesId);
-              creatingDebouncers.delete(SeriesId);
+              debouncedSenders.delete(seriesKey);
+              creatingDebouncers.delete(seriesKey);
               // Clear temp marker (-1) so the series is not blocked for 24h after a failed notification
-              if (sentNotifications.has(SeriesId)) {
-                const existing = sentNotifications.get(SeriesId);
+              if (sentNotifications.has(seriesKey)) {
+                const existing = sentNotifications.get(seriesKey);
                 if (existing.cleanupTimer) clearTimeout(existing.cleanupTimer);
-                if (existing.level === -1) sentNotifications.delete(SeriesId);
+                if (existing.level === -1) sentNotifications.delete(seriesKey);
               }
             }
           },
           debounceMs
         );
 
-        debouncedSenders.set(SeriesId, {
+        debouncedSenders.set(seriesKey, {
           sender: newDebouncedSender,
           latestData: data,
           episodeCount: 0,
@@ -1253,20 +1268,20 @@ export async function handleJellyfinWebhook(req, res, client, pendingRequests, o
         });
 
         // Remove from creatingDebouncers now that it's been added to debouncedSenders
-        creatingDebouncers.delete(SeriesId);
+        creatingDebouncers.delete(seriesKey);
 
         // Mark this series as being processed immediately to prevent duplicate debouncers
         // This will be updated with the final level once the debounced notification is sent
         const tempCleanupTimer = setTimeout(() => {
           // Only clean up if debouncer is no longer active
           if (
-            !debouncedSenders.has(SeriesId) &&
-            sentNotifications.has(SeriesId)
+            !debouncedSenders.has(seriesKey) &&
+            sentNotifications.has(seriesKey)
           ) {
-            const notification = sentNotifications.get(SeriesId);
+            const notification = sentNotifications.get(seriesKey);
             // Only delete if this is still the temp marker (level: -1)
             if (notification.level === -1) {
-              sentNotifications.delete(SeriesId);
+              sentNotifications.delete(seriesKey);
               logger.debug(
                 `Cleaned up temporary notification marker for SeriesId: ${SeriesId}`
               );
@@ -1274,7 +1289,7 @@ export async function handleJellyfinWebhook(req, res, client, pendingRequests, o
           }
         }, 5 * 60 * 1000); // 5 minutes — short enough that a failed debounce doesn't block the series for long
 
-        sentNotifications.set(SeriesId, {
+        sentNotifications.set(seriesKey, {
           level: -1, // Temporary marker indicating processing is in progress
           timestamp: Date.now(),
           cleanupTimer: tempCleanupTimer,
@@ -1282,11 +1297,11 @@ export async function handleJellyfinWebhook(req, res, client, pendingRequests, o
       }
 
       // Update the data to be sent with the highest-level notification received so far.
-      logger.info(`[DEBOUNCER] Getting existing debouncer for SeriesId: ${SeriesId}, exists: ${debouncedSenders.has(SeriesId)}`);
-      const debouncer = debouncedSenders.get(SeriesId);
-      
+      logger.info(`[DEBOUNCER] Getting existing debouncer for SeriesId: ${SeriesId}, exists: ${debouncedSenders.has(seriesKey)}`);
+      const debouncer = debouncedSenders.get(seriesKey);
+
       if (!debouncer) {
-        logger.error(`[DEBOUNCER] ERROR: Debouncer not found for SeriesId: ${SeriesId} even though has() returned ${debouncedSenders.has(SeriesId)}`);
+        logger.error(`[DEBOUNCER] ERROR: Debouncer not found for SeriesId: ${SeriesId} even though has() returned ${debouncedSenders.has(seriesKey)}`);
         if (res) return res.status(500).send("Internal error: debouncer not found");
         return;
       }

--- a/jellyfinWebhook.js
+++ b/jellyfinWebhook.js
@@ -959,7 +959,6 @@ export async function handleJellyfinWebhook(req, res, client, pendingRequests, o
       const isTestMovie = ItemId && ItemId.startsWith("test-");
       const movieKey = isTestMovie ? `test:${ItemId}` : (buildIdentityKey(data) || `id:${ItemId}`);
 
-      // Check if we already sent a notification for this movie (identity-keyed, survives upgrades)
       if (sentNotifications.has(movieKey)) {
         logger.info(
           `[DEDUP] Duplicate movie notification suppressed for "${data.Name}" (key: ${movieKey})`
@@ -986,10 +985,7 @@ export async function handleJellyfinWebhook(req, res, client, pendingRequests, o
         isAnimeLibrary
       );
 
-      // Mark this movie as notified — TTL handled by PersistentMap, survives restart
-      sentNotifications.set(movieKey, {
-        level: 0, // Movies don't have hierarchy levels
-      });
+      sentNotifications.set(movieKey, { level: 0 });
 
       if (res) return res.status(200).send("OK: Movie notification sent.");
       return; // Exit early to prevent fallthrough to unknown item type handler
@@ -1004,8 +1000,7 @@ export async function handleJellyfinWebhook(req, res, client, pendingRequests, o
       const SeriesId =
         data.SeriesId || (data.ItemType === "Series" ? data.ItemId : null);
 
-      // Build an upgrade-stable series-level identity key for sentNotifications.
-      // Episodes/Seasons fold into the series-level entry by reusing the Series identity.
+      // Episodes/Seasons fold into a series-level entry by reusing the Series identity.
       const seriesIdentityInput = {
         ItemType: "Series",
         Provider_tmdb: data.Provider_tmdb,
@@ -1216,7 +1211,6 @@ export async function handleJellyfinWebhook(req, res, client, pendingRequests, o
 
               const levelSent = getItemLevel(latestData.ItemType);
 
-              // Mark series as notified — TTL handled by PersistentMap, survives restart.
               // Overwrites any temporary level=-1 marker.
               sentNotifications.set(seriesKey, {
                 level: levelSent,

--- a/jellyfinWebhook.js
+++ b/jellyfinWebhook.js
@@ -17,9 +17,15 @@ import {
   getLibraryAnimeFlag,
   buildIdentityKey,
 } from "./jellyfin/libraryResolver.js";
+import { PersistentMap } from "./utils/persistentMap.js";
 
 const debouncedSenders = new Map();
-const sentNotifications = new Map();
+// Persistent so dedup state survives container restarts (otherwise a restart
+// re-notifies anything in the recently-added window via the next poll/WS reconnect).
+const sentNotifications = new PersistentMap(
+  "sent-notifications",
+  7 * 24 * 60 * 60 * 1000 // 7 days — survive Sonarr/Radarr upgrade cycles
+);
 const episodeMessages = new Map(); // Track Discord messages for editing: SeriesId -> { messageId, channelId }
 const creatingDebouncers = new Set(); // Prevent race condition: track SeriesIds currently creating debouncers
 
@@ -53,7 +59,6 @@ const CLEANUP_THRESHOLD_MS = 14 * 24 * 60 * 60 * 1000; // 14 days — periodic c
 const DEFAULT_DEBOUNCE_MS = 60000; // 60 seconds
 const NEW_SERIES_DEBOUNCE_MS = 120000; // 2 minutes - longer debounce for episodes/seasons of new series
 const SEASON_NOTIFICATION_DELAY_MS = 3 * 60 * 1000; // 3 minutes - allow season notifications after this delay
-const SENT_NOTIFICATION_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days — survive Sonarr/Radarr upgrade cycles
 
 // Periodic cleanup for old debouncer entries and API cache (prevent memory leaks on long-running servers)
 setInterval(() => {
@@ -969,17 +974,9 @@ export async function handleJellyfinWebhook(req, res, client, pendingRequests, o
         isAnimeLibrary
       );
 
-      // Mark this movie as notified — 7d TTL covers typical Sonarr/Radarr upgrade window
-      const cleanupTimer = setTimeout(() => {
-        sentNotifications.delete(movieKey);
-        logger.debug(
-          `Cleaned up movie notification state for key: ${movieKey}`
-        );
-      }, SENT_NOTIFICATION_TTL_MS);
-
+      // Mark this movie as notified — TTL handled by PersistentMap, survives restart
       sentNotifications.set(movieKey, {
         level: 0, // Movies don't have hierarchy levels
-        cleanupTimer: cleanupTimer,
       });
 
       if (res) return res.status(200).send("OK: Movie notification sent.");
@@ -1207,27 +1204,11 @@ export async function handleJellyfinWebhook(req, res, client, pendingRequests, o
 
               const levelSent = getItemLevel(latestData.ItemType);
 
-              // Clear any existing cleanup timer (from temporary marker)
-              if (sentNotifications.has(seriesKey)) {
-                const existingNotification = sentNotifications.get(seriesKey);
-                if (existingNotification.cleanupTimer) {
-                  clearTimeout(existingNotification.cleanupTimer);
-                }
-              }
-
-              // Set a cleanup timer for the 'sent' notification state
-              // Use a longer duration to prevent duplicate notifications from delayed webhooks
-              const cleanupTimer = setTimeout(() => {
-                sentNotifications.delete(seriesKey);
-                logger.debug(
-                  `Cleaned up sent notification state for SeriesId: ${SeriesId}`
-                );
-              }, SENT_NOTIFICATION_TTL_MS);
-
+              // Mark series as notified — TTL handled by PersistentMap, survives restart.
+              // Overwrites any temporary level=-1 marker.
               sentNotifications.set(seriesKey, {
                 level: levelSent,
                 timestamp: Date.now(),
-                cleanupTimer: cleanupTimer,
               });
               logger.info(
                 `[SENT NOTIFICATION] Set sentLevel=${levelSent} for SeriesId ${SeriesId} (${latestData.Name})`
@@ -1244,10 +1225,9 @@ export async function handleJellyfinWebhook(req, res, client, pendingRequests, o
               // Cleanup all maps on error so future webhooks for this series are not blocked
               debouncedSenders.delete(seriesKey);
               creatingDebouncers.delete(seriesKey);
-              // Clear temp marker (-1) so the series is not blocked for 24h after a failed notification
+              // Clear temp marker (-1) so the series is not blocked after a failed notification
               if (sentNotifications.has(seriesKey)) {
                 const existing = sentNotifications.get(seriesKey);
-                if (existing.cleanupTimer) clearTimeout(existing.cleanupTimer);
                 if (existing.level === -1) sentNotifications.delete(seriesKey);
               }
             }
@@ -1270,30 +1250,18 @@ export async function handleJellyfinWebhook(req, res, client, pendingRequests, o
         // Remove from creatingDebouncers now that it's been added to debouncedSenders
         creatingDebouncers.delete(seriesKey);
 
-        // Mark this series as being processed immediately to prevent duplicate debouncers
-        // This will be updated with the final level once the debounced notification is sent
-        const tempCleanupTimer = setTimeout(() => {
-          // Only clean up if debouncer is no longer active
-          if (
-            !debouncedSenders.has(seriesKey) &&
-            sentNotifications.has(seriesKey)
-          ) {
-            const notification = sentNotifications.get(seriesKey);
-            // Only delete if this is still the temp marker (level: -1)
-            if (notification.level === -1) {
-              sentNotifications.delete(seriesKey);
-              logger.debug(
-                `Cleaned up temporary notification marker for SeriesId: ${SeriesId}`
-              );
-            }
-          }
-        }, 5 * 60 * 1000); // 5 minutes — short enough that a failed debounce doesn't block the series for long
-
-        sentNotifications.set(seriesKey, {
-          level: -1, // Temporary marker indicating processing is in progress
-          timestamp: Date.now(),
-          cleanupTimer: tempCleanupTimer,
-        });
+        // Mark this series as being processed immediately to prevent duplicate debouncers.
+        // 5-minute per-entry TTL: if the debouncer fires (typically within 60-120s),
+        // the entry gets overwritten with the real level; if it never fires (stuck or
+        // crashed), the marker expires on its own so the series isn't blocked indefinitely.
+        sentNotifications.set(
+          seriesKey,
+          {
+            level: -1, // Temporary marker indicating processing is in progress
+            timestamp: Date.now(),
+          },
+          5 * 60 * 1000
+        );
       }
 
       // Update the data to be sent with the highest-level notification received so far.

--- a/jellyfinWebhook.js
+++ b/jellyfinWebhook.js
@@ -24,7 +24,8 @@ const debouncedSenders = new Map();
 // re-notifies anything in the recently-added window via the next poll/WS reconnect).
 const sentNotifications = new PersistentMap(
   "sent-notifications",
-  7 * 24 * 60 * 60 * 1000 // 7 days — survive Sonarr/Radarr upgrade cycles
+  7 * 24 * 60 * 60 * 1000, // 7 days — survive Sonarr/Radarr upgrade cycles
+  { validateValue: (v) => v && typeof v.level === "number" }
 );
 
 // Sweep stale "in-progress" markers (level: -1) from a previous run. Their

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anchorr",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "main": "app.js",
   "scripts": {
     "start": "node app.js",

--- a/utils/persistentMap.js
+++ b/utils/persistentMap.js
@@ -39,49 +39,90 @@ function installShutdownHooks() {
  *
  * Used for dedup state — losing a few seconds of writes on hard crash
  * is acceptable; the worst outcome is one extra Discord notification.
+ *
+ * Options:
+ *   - validateValue(value): optional predicate. Entries whose value fails
+ *     the check are dropped on load (defends against tampered/corrupt files).
  */
 export class PersistentMap {
-  constructor(name, defaultTtlMs) {
+  constructor(name, defaultTtlMs, options = {}) {
     this.name = name;
     this.defaultTtlMs = defaultTtlMs;
+    this.validateValue = options.validateValue;
     this.filePath = path.join(path.dirname(CONFIG_PATH), `dedup-${name}.json`);
     this.entries = new Map();
     this.flushTimer = null;
     this.dirty = false;
+    this.consecutiveFlushFailures = 0;
     this._load();
     registry.add(this);
     installShutdownHooks();
   }
 
-  _load() {
+  _quarantine(reason) {
     try {
-      if (!fs.existsSync(this.filePath)) return;
-      const raw = fs.readFileSync(this.filePath, "utf-8");
-      const parsed = JSON.parse(raw);
-      if (!Array.isArray(parsed)) {
-        logger.warn(`PersistentMap[${this.name}]: file content is not an array, ignoring`);
-        return;
-      }
-      const now = Date.now();
-      let loaded = 0;
-      let dropped = 0;
-      for (const entry of parsed) {
-        if (!entry || typeof entry !== "object") continue;
-        const { key, value, expiresAt } = entry;
-        if (typeof key !== "string" || typeof expiresAt !== "number") continue;
-        if (expiresAt <= now) {
-          dropped++;
-          continue;
-        }
-        this.entries.set(key, { value, expiresAt });
-        loaded++;
-      }
-      logger.info(
-        `PersistentMap[${this.name}]: loaded ${loaded} entries from ${this.filePath} (dropped ${dropped} expired)`
+      const dest = `${this.filePath}.corrupt-${Date.now()}`;
+      fs.renameSync(this.filePath, dest);
+      logger.warn(
+        `PersistentMap[${this.name}]: quarantined corrupt file to ${dest} (${reason})`
       );
     } catch (err) {
-      logger.warn(`PersistentMap[${this.name}]: failed to load (${err?.message || err})`);
+      logger.warn(
+        `PersistentMap[${this.name}]: failed to quarantine corrupt file (${err?.message || err})`
+      );
     }
+  }
+
+  _load() {
+    if (!fs.existsSync(this.filePath)) return;
+    let raw;
+    try {
+      raw = fs.readFileSync(this.filePath, "utf-8");
+    } catch (err) {
+      // IO error — keep file as-is so it isn't overwritten on first flush.
+      logger.warn(`PersistentMap[${this.name}]: read failed (${err?.message || err})`);
+      return;
+    }
+    let parsed;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (err) {
+      this._quarantine(`parse error: ${err?.message || err}`);
+      return;
+    }
+    if (!Array.isArray(parsed)) {
+      this._quarantine("file content is not an array");
+      return;
+    }
+    const now = Date.now();
+    let loaded = 0;
+    let dropped = 0;
+    let invalid = 0;
+    for (const entry of parsed) {
+      if (!entry || typeof entry !== "object") {
+        invalid++;
+        continue;
+      }
+      const { key, value, expiresAt } = entry;
+      if (typeof key !== "string" || typeof expiresAt !== "number") {
+        invalid++;
+        continue;
+      }
+      if (expiresAt <= now) {
+        dropped++;
+        continue;
+      }
+      if (this.validateValue && !this.validateValue(value)) {
+        invalid++;
+        continue;
+      }
+      this.entries.set(key, { value, expiresAt });
+      loaded++;
+    }
+    logger.info(
+      `PersistentMap[${this.name}]: loaded ${loaded} entries from ${this.filePath} (dropped ${dropped} expired, ${invalid} invalid)`
+    );
+    if (invalid > 0) this._scheduleFlush(); // rewrite without bad entries
   }
 
   _scheduleFlush() {
@@ -110,9 +151,20 @@ export class PersistentMap {
       const tmpPath = `${this.filePath}.tmp`;
       fs.writeFileSync(tmpPath, JSON.stringify(data), { mode: 0o600 });
       fs.renameSync(tmpPath, this.filePath);
+      if (this.consecutiveFlushFailures > 0) {
+        logger.info(
+          `PersistentMap[${this.name}]: flush recovered after ${this.consecutiveFlushFailures} failure(s)`
+        );
+        this.consecutiveFlushFailures = 0;
+      }
     } catch (err) {
-      logger.warn(`PersistentMap[${this.name}]: flush failed (${err?.message || err})`);
       this.dirty = true;
+      this.consecutiveFlushFailures++;
+      // First failure visible at warn; subsequent ones at debug to avoid
+      // log floods (e.g. disk full + bursty writes every 2s).
+      const msg = `PersistentMap[${this.name}]: flush failed #${this.consecutiveFlushFailures} (${err?.message || err})`;
+      if (this.consecutiveFlushFailures === 1) logger.warn(msg);
+      else logger.debug(msg);
     }
   }
 

--- a/utils/persistentMap.js
+++ b/utils/persistentMap.js
@@ -1,0 +1,163 @@
+import fs from "fs";
+import path from "path";
+import logger from "./logger.js";
+import { CONFIG_PATH } from "./configFile.js";
+
+const FLUSH_DEBOUNCE_MS = 2000;
+
+const registry = new Set();
+let shutdownHooksInstalled = false;
+
+function installShutdownHooks() {
+  if (shutdownHooksInstalled) return;
+  shutdownHooksInstalled = true;
+  const flushAll = () => {
+    for (const m of registry) {
+      try {
+        m.flush();
+      } catch (err) {
+        logger.warn(`PersistentMap shutdown flush failed: ${err?.message || err}`);
+      }
+    }
+  };
+  process.on("SIGTERM", flushAll);
+  process.on("SIGINT", flushAll);
+  process.on("beforeExit", flushAll);
+}
+
+/**
+ * Map-like store with per-entry TTL that survives process restarts.
+ *
+ * Persists to a JSON file next to config.json. Mutations schedule a
+ * debounced atomic write (tmp file + rename) so we don't thrash the disk
+ * on bursty traffic. Expired entries are dropped lazily on access and
+ * eagerly on load/cleanup.
+ *
+ * Used for dedup state — losing a few seconds of writes on hard crash
+ * is acceptable; the worst outcome is one extra Discord notification.
+ */
+export class PersistentMap {
+  constructor(name, defaultTtlMs) {
+    this.name = name;
+    this.defaultTtlMs = defaultTtlMs;
+    this.filePath = path.join(path.dirname(CONFIG_PATH), `dedup-${name}.json`);
+    this.entries = new Map();
+    this.flushTimer = null;
+    this.dirty = false;
+    this._load();
+    registry.add(this);
+    installShutdownHooks();
+  }
+
+  _load() {
+    try {
+      if (!fs.existsSync(this.filePath)) return;
+      const raw = fs.readFileSync(this.filePath, "utf-8");
+      const parsed = JSON.parse(raw);
+      if (!Array.isArray(parsed)) {
+        logger.warn(`PersistentMap[${this.name}]: file content is not an array, ignoring`);
+        return;
+      }
+      const now = Date.now();
+      let loaded = 0;
+      let dropped = 0;
+      for (const entry of parsed) {
+        if (!entry || typeof entry !== "object") continue;
+        const { key, value, expiresAt } = entry;
+        if (typeof key !== "string" || typeof expiresAt !== "number") continue;
+        if (expiresAt <= now) {
+          dropped++;
+          continue;
+        }
+        this.entries.set(key, { value, expiresAt });
+        loaded++;
+      }
+      logger.info(
+        `PersistentMap[${this.name}]: loaded ${loaded} entries from ${this.filePath} (dropped ${dropped} expired)`
+      );
+    } catch (err) {
+      logger.warn(`PersistentMap[${this.name}]: failed to load (${err?.message || err})`);
+    }
+  }
+
+  _scheduleFlush() {
+    this.dirty = true;
+    if (this.flushTimer) return;
+    this.flushTimer = setTimeout(() => this.flush(), FLUSH_DEBOUNCE_MS);
+  }
+
+  flush() {
+    if (this.flushTimer) {
+      clearTimeout(this.flushTimer);
+      this.flushTimer = null;
+    }
+    if (!this.dirty) return;
+    this.dirty = false;
+    const now = Date.now();
+    const data = [];
+    for (const [key, entry] of this.entries) {
+      if (entry.expiresAt > now) {
+        data.push({ key, value: entry.value, expiresAt: entry.expiresAt });
+      }
+    }
+    try {
+      const dir = path.dirname(this.filePath);
+      if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+      const tmpPath = `${this.filePath}.tmp`;
+      fs.writeFileSync(tmpPath, JSON.stringify(data), { mode: 0o600 });
+      fs.renameSync(tmpPath, this.filePath);
+    } catch (err) {
+      logger.warn(`PersistentMap[${this.name}]: flush failed (${err?.message || err})`);
+      this.dirty = true;
+    }
+  }
+
+  has(key) {
+    const entry = this.entries.get(key);
+    if (!entry) return false;
+    if (entry.expiresAt <= Date.now()) {
+      this.entries.delete(key);
+      this._scheduleFlush();
+      return false;
+    }
+    return true;
+  }
+
+  get(key) {
+    const entry = this.entries.get(key);
+    if (!entry) return undefined;
+    if (entry.expiresAt <= Date.now()) {
+      this.entries.delete(key);
+      this._scheduleFlush();
+      return undefined;
+    }
+    return entry.value;
+  }
+
+  set(key, value, ttlMs) {
+    const expiresAt = Date.now() + (ttlMs ?? this.defaultTtlMs);
+    this.entries.set(key, { value, expiresAt });
+    this._scheduleFlush();
+  }
+
+  delete(key) {
+    if (this.entries.delete(key)) this._scheduleFlush();
+  }
+
+  cleanup() {
+    const now = Date.now();
+    let removed = 0;
+    for (const [key, entry] of this.entries) {
+      if (entry.expiresAt <= now) {
+        this.entries.delete(key);
+        removed++;
+      }
+    }
+    if (removed > 0) this._scheduleFlush();
+    return removed;
+  }
+
+  size() {
+    return this.entries.size;
+  }
+}

--- a/utils/persistentMap.js
+++ b/utils/persistentMap.js
@@ -20,6 +20,10 @@ function installShutdownHooks() {
       }
     }
   };
+  // Process termination is owned by app.js (which calls process.exit(0) after
+  // server.close). These additional listeners run synchronously alongside it
+  // to flush dirty state before exit; we deliberately do not call exit here
+  // to avoid racing app.js's graceful shutdown.
   process.on("SIGTERM", flushAll);
   process.on("SIGINT", flushAll);
   process.on("beforeExit", flushAll);
@@ -149,6 +153,19 @@ export class PersistentMap {
     let removed = 0;
     for (const [key, entry] of this.entries) {
       if (entry.expiresAt <= now) {
+        this.entries.delete(key);
+        removed++;
+      }
+    }
+    if (removed > 0) this._scheduleFlush();
+    return removed;
+  }
+
+  /** Drop entries matching the predicate. Returns count removed. */
+  prune(predicate) {
+    let removed = 0;
+    for (const [key, entry] of this.entries) {
+      if (predicate(key, entry.value)) {
         this.entries.delete(key);
         removed++;
       }


### PR DESCRIPTION
## Problem

Sonarr/Radarr quality upgrades replace a file, and Jellyfin assigns the new file a fresh `ItemId`. Dedup was keyed on `ItemId`, so the upgrade looked like a brand-new item and Discord got a second notification.

A second issue surfaced during the fix: dedup state lived only in memory, so a container restart wiped it and re-notified everything still in the recently-added window.

## Fix

- **Identity-based dedup.** Webhook, poller, and WebSocket paths now key on stable identity (TMDB ID for movies, TMDB + S/E for episodes) instead of `ItemId`. Upgrades keep the same key.
- **Persistent state.** New `PersistentMap` utility writes dedup state to `config/dedup-*.json` (debounced atomic writes, 0o600, per-entry TTL). Reloaded on startup.
- **Dedup window** raised to 7 days to cover typical upgrade cycles.
- **Cleanup simplified.** Manual `setTimeout` cleanup in the webhook is gone — TTL is handled per-entry. Stale `level: -1` in-progress markers from a previous run are swept on startup so they can't block a series after restart.

**Trade-off:** a deliberate re-add of the same content within 7 days is suppressed. Acceptable for the bug this fixes.

## Verification

Three webhook curl phases against a local instance:

1. Same content, two different `ItemId`s → one Discord message, second logs `[DEDUP] Duplicate movie notification suppressed`.
2. Restart the bot, third curl with same TMDB but new `ItemId` → no notification. Log shows `PersistentMap[sent-notifications]: loaded 1 entries` (state reloaded from disk).
3. Genuine new movie (different TMDB) → notification fires (negative control).

---

> AI-assisted documentation. Code logic manually verified.