### PR TITLE
fix(roundup): correct date filter, add installedAt floor, TZ-aware scheduler

### DIFF
--- a/api/jellyfin.js
+++ b/api/jellyfin.js
@@ -461,15 +461,32 @@ export async function fetchRecentlyAdded(
     const cutoffMs = new Date(minDateCreated).getTime();
     const collected = [];
     let startIndex = 0;
+    let stopReason = "loop-exit";
     while (collected.length < maxTotal) {
       const params = { ...baseParams, StartIndex: startIndex };
-      const response = await axios.get(url, {
-        headers: { "X-MediaBrowser-Token": apiKey },
-        params,
-        timeout: 10000,
-      });
-      const page = response.data?.Items || [];
-      if (page.length === 0) break;
+      let page;
+      try {
+        const response = await axios.get(url, {
+          headers: { "X-MediaBrowser-Token": apiKey },
+          params,
+          timeout: 10000,
+        });
+        page = response.data?.Items || [];
+      } catch (err) {
+        // Per-page failure: keep what we have, surface a warning, stop.
+        // Returning the partial set is better than throwing the whole call
+        // away — the caller's downstream filters tolerate fewer items
+        // gracefully (it just means a thinner roundup that week).
+        logger.warn(
+          `fetchRecentlyAdded: page at StartIndex=${startIndex} failed (${err?.message || err}); returning ${collected.length} items collected so far`
+        );
+        stopReason = "page-error";
+        break;
+      }
+      if (page.length === 0) {
+        stopReason = "empty-page";
+        break;
+      }
 
       let stop = false;
       for (const item of page) {
@@ -478,21 +495,29 @@ export async function fetchRecentlyAdded(
           : NaN;
         if (Number.isFinite(created) && created < cutoffMs) {
           stop = true;
+          stopReason = "cutoff-hit";
           break;
         }
         collected.push(item);
         if (collected.length >= maxTotal) {
           stop = true;
+          stopReason = "max-total-hit";
+          logger.warn(
+            `fetchRecentlyAdded: hit maxTotal=${maxTotal} cap; older items in this window were truncated`
+          );
           break;
         }
       }
       if (stop) break;
-      if (page.length < limit) break;
+      if (page.length < limit) {
+        stopReason = "short-page";
+        break;
+      }
       startIndex += page.length;
     }
 
     logger.debug(
-      `Fetched ${collected.length} recently added items from Jellyfin (since ${minDateCreated}, paginated)`
+      `Fetched ${collected.length} recently added items from Jellyfin (since ${minDateCreated}, paginated, stop=${stopReason})`
     );
     return collected;
   } catch (err) {

--- a/api/jellyfin.js
+++ b/api/jellyfin.js
@@ -409,22 +409,28 @@ export async function findLibraryId(
   }
 }
 
+const FETCH_RECENTLY_ADDED_MAX_TOTAL = 5000;
+
 /**
- * Fetch recently added items from Jellyfin.
- *
- * @param {string} apiKey - Jellyfin API key
- * @param {string} baseUrl - Jellyfin base URL
- * @param {number} limit - Maximum number of items to fetch (default: 50)
- * @param {string} [minDateCreated] - Optional ISO timestamp cutoff (inclusive).
- *   When provided, only items created at or after this time are returned.
- * @returns {Promise<Array>} Array of recently added items
+ * Fetch recently added items. With `minDateCreated`, paginates via
+ * StartIndex/Limit and breaks early once items fall below the cutoff
+ * (results are DateCreated desc). Server-side filter is `MinDateLastSaved`
+ * — Jellyfin silently ignores `MinDateCreated` — so callers must still
+ * filter by `DateCreated` client-side.
  */
-export async function fetchRecentlyAdded(apiKey, baseUrl, limit = 50, minDateCreated, parentId) {
+export async function fetchRecentlyAdded(
+  apiKey,
+  baseUrl,
+  limit = 50,
+  minDateCreated,
+  parentId,
+  maxTotal = FETCH_RECENTLY_ADDED_MAX_TOTAL
+) {
   try {
     const safeBase = new URL(baseUrl);
     safeBase.pathname = safeBase.pathname.replace(/\/$/, "") + "/Items";
     const url = safeBase.href;
-    const params = {
+    const baseParams = {
       SortBy: "DateCreated",
       SortOrder: "Descending",
       Limit: limit,
@@ -433,24 +439,62 @@ export async function fetchRecentlyAdded(apiKey, baseUrl, limit = 50, minDateCre
       Recursive: true,
     };
     if (minDateCreated) {
-      params.MinDateCreated = minDateCreated;
+      baseParams.MinDateLastSaved = minDateCreated;
     }
     if (parentId) {
-      params.ParentId = parentId;
+      baseParams.ParentId = parentId;
     }
-    const response = await axios.get(url, {
-      headers: { "X-MediaBrowser-Token": apiKey },
-      params,
-      timeout: 10000,
-    });
 
-    const items = response.data?.Items || response.data || [];
+    if (!minDateCreated) {
+      const response = await axios.get(url, {
+        headers: { "X-MediaBrowser-Token": apiKey },
+        params: baseParams,
+        timeout: 10000,
+      });
+      const items = response.data?.Items || response.data || [];
+      logger.debug(
+        `Fetched ${items.length} recently added items from Jellyfin`
+      );
+      return items;
+    }
+
+    const cutoffMs = new Date(minDateCreated).getTime();
+    const collected = [];
+    let startIndex = 0;
+    while (collected.length < maxTotal) {
+      const params = { ...baseParams, StartIndex: startIndex };
+      const response = await axios.get(url, {
+        headers: { "X-MediaBrowser-Token": apiKey },
+        params,
+        timeout: 10000,
+      });
+      const page = response.data?.Items || [];
+      if (page.length === 0) break;
+
+      let stop = false;
+      for (const item of page) {
+        const created = item.DateCreated
+          ? new Date(item.DateCreated).getTime()
+          : NaN;
+        if (Number.isFinite(created) && created < cutoffMs) {
+          stop = true;
+          break;
+        }
+        collected.push(item);
+        if (collected.length >= maxTotal) {
+          stop = true;
+          break;
+        }
+      }
+      if (stop) break;
+      if (page.length < limit) break;
+      startIndex += page.length;
+    }
+
     logger.debug(
-      `Fetched ${items.length} recently added items from Jellyfin${
-        minDateCreated ? ` (since ${minDateCreated})` : ""
-      }`
+      `Fetched ${collected.length} recently added items from Jellyfin (since ${minDateCreated}, paginated)`
     );
-    return items;
+    return collected;
   } catch (err) {
     logger.error(
       "Failed to fetch recently added items from Jellyfin:",

--- a/bot/roundupState.js
+++ b/bot/roundupState.js
@@ -1,4 +1,5 @@
 import { PersistentMap } from "../utils/persistentMap.js";
+import logger from "../utils/logger.js";
 
 const NEVER_TTL_MS = 100 * 365 * 24 * 60 * 60 * 1000;
 
@@ -13,6 +14,12 @@ export function getInstalledAt(now = Date.now()) {
   if (typeof existing === "number" && Number.isFinite(existing)) {
     return existing;
   }
+  // First time we've stamped this — or the persisted value was rejected
+  // by validateValue on load (PersistentMap logs the drop). Either way,
+  // surface it: an unexpected restamp resets the back-catalogue floor.
+  logger.info(
+    `roundup-state: stamping installedAt=${new Date(now).toISOString()} (no prior value found)`
+  );
   map.set(INSTALLED_AT_KEY, now);
   return now;
 }

--- a/bot/roundupState.js
+++ b/bot/roundupState.js
@@ -1,0 +1,18 @@
+import { PersistentMap } from "../utils/persistentMap.js";
+
+const NEVER_TTL_MS = 100 * 365 * 24 * 60 * 60 * 1000;
+
+const map = new PersistentMap("roundup-state", NEVER_TTL_MS, {
+  validateValue: (v) => typeof v === "number" && Number.isFinite(v),
+});
+
+const INSTALLED_AT_KEY = "installedAt";
+
+export function getInstalledAt(now = Date.now()) {
+  const existing = map.get(INSTALLED_AT_KEY);
+  if (typeof existing === "number" && Number.isFinite(existing)) {
+    return existing;
+  }
+  map.set(INSTALLED_AT_KEY, now);
+  return now;
+}

--- a/bot/weeklyRoundup.js
+++ b/bot/weeklyRoundup.js
@@ -59,12 +59,26 @@ export function scheduleWeeklyRoundup(client) {
     clearInterval(roundupTimer);
   }
 
-  // Idempotent — records on first ever call only. Doing it at scheduler
-  // start (not lazily) stamps the floor before any back-catalogue can leak
-  // into the first roundup after an upgrade.
+  // Stamp the back-catalogue floor at scheduler start, not lazily on first
+  // tick — otherwise items added in the days between bot start and the
+  // first weekly tick can be misclassified later.
   const installedAt = getInstalledAt();
+
+  // Validate WEEKLY_ROUNDUP_TZ once, loudly, at boot. The per-tick resolver
+  // logs at debug level so a misconfig doesn't spam the log every hour.
+  const tz = process.env.WEEKLY_ROUNDUP_TZ;
+  if (tz) {
+    try {
+      new Intl.DateTimeFormat("en-US", { timeZone: tz });
+    } catch (err) {
+      logger.warn(
+        `Weekly Roundup: WEEKLY_ROUNDUP_TZ="${tz}" is not a valid IANA timezone (${err?.message || err}). The scheduler will fall back to host time until this is fixed.`
+      );
+    }
+  }
+
   logger.info(
-    `📦 Weekly Roundup scheduler started (hourly tick, installedAt=${new Date(installedAt).toISOString()})`
+    `📦 Weekly Roundup scheduler started (hourly tick, installedAt=${new Date(installedAt).toISOString()}${tz ? `, tz=${tz}` : ""})`
   );
 
   // Initial tick after startup so startup logs settle first.
@@ -114,8 +128,10 @@ function resolveLocalWeekdayHour(now) {
     }
     return { weekday, hour };
   } catch (err) {
-    logger.warn(
-      `Weekly Roundup: invalid WEEKLY_ROUNDUP_TZ "${tz}" (${err?.message || err}), falling back to host time`
+    // Boot-time validator already warned loudly; downgrade per-tick log
+    // to debug to avoid hourly spam while the misconfig persists.
+    logger.debug(
+      `Weekly Roundup: WEEKLY_ROUNDUP_TZ "${tz}" unparseable (${err?.message || err}); using host time`
     );
     return { weekday: now.getDay(), hour: now.getHours() };
   }
@@ -491,14 +507,22 @@ async function sendWeeklyRoundup(client, channelId, now, options = {}) {
   const beforeFilter = items.length;
   let droppedPreInstall = 0;
   let droppedOldDateCreated = 0;
+  let droppedNoDateCreated = 0;
   let droppedAlreadySeen = 0;
   const fresh = items.filter((item) => {
     const created = item.DateCreated ? new Date(item.DateCreated).getTime() : NaN;
-    if (Number.isFinite(created) && created < installedAt) {
+    if (!Number.isFinite(created)) {
+      // Safer default for a "what's new this week" digest: an item without
+      // a usable DateCreated could just as easily be 5 years old as 5
+      // minutes old. Drop and count rather than letting it through.
+      droppedNoDateCreated++;
+      return false;
+    }
+    if (created < installedAt) {
       droppedPreInstall++;
       return false;
     }
-    if (Number.isFinite(created) && created < cutoffMs) {
+    if (created < cutoffMs) {
       droppedOldDateCreated++;
       return false;
     }
@@ -509,11 +533,9 @@ async function sendWeeklyRoundup(client, channelId, now, options = {}) {
     }
     return true;
   });
-  if (beforeFilter !== fresh.length) {
-    logger.debug(
-      `${logPrefix}: filtered ${beforeFilter} → ${fresh.length} items (pre-install: ${droppedPreInstall}, old DateCreated: ${droppedOldDateCreated}, already-seen: ${droppedAlreadySeen})`
-    );
-  }
+  logger.debug(
+    `${logPrefix}: filtered ${beforeFilter} → ${fresh.length} items (no DateCreated: ${droppedNoDateCreated}, pre-install: ${droppedPreInstall}, old DateCreated: ${droppedOldDateCreated}, already-seen: ${droppedAlreadySeen})`
+  );
   // Preserve the diagnostic counters from fetchWindowItems on the filtered
   // array (filter() drops these expando properties).
   fresh.rawCount = items.rawCount;

--- a/bot/weeklyRoundup.js
+++ b/bot/weeklyRoundup.js
@@ -6,6 +6,7 @@ import { updateConfig } from "../utils/configFile.js";
 import { t } from "../utils/i18n.js";
 import logger from "../utils/logger.js";
 import { recordOrGet } from "./roundupFirstSeen.js";
+import { getInstalledAt } from "./roundupState.js";
 
 // Hourly tick interval — do not change without updating the idempotency guard.
 const TICK_INTERVAL_MS = 60 * 60 * 1000;
@@ -58,7 +59,13 @@ export function scheduleWeeklyRoundup(client) {
     clearInterval(roundupTimer);
   }
 
-  logger.info("📦 Weekly Roundup scheduler started (hourly tick)");
+  // Idempotent — records on first ever call only. Doing it at scheduler
+  // start (not lazily) stamps the floor before any back-catalogue can leak
+  // into the first roundup after an upgrade.
+  const installedAt = getInstalledAt();
+  logger.info(
+    `📦 Weekly Roundup scheduler started (hourly tick, installedAt=${new Date(installedAt).toISOString()})`
+  );
 
   // Initial tick after startup so startup logs settle first.
   setTimeout(() => {
@@ -78,6 +85,40 @@ function parseIntInRange(raw, fallback, min, max) {
   const n = parseInt(raw, 10);
   if (Number.isNaN(n) || n < min || n > max) return fallback;
   return n;
+}
+
+// Returns weekday (0=Sun..6=Sat) and hour (0..23). Defaults to host time
+// (respects host TZ env); WEEKLY_ROUNDUP_TZ overrides via Intl.
+function resolveLocalWeekdayHour(now) {
+  const tz = process.env.WEEKLY_ROUNDUP_TZ;
+  if (!tz) {
+    return { weekday: now.getDay(), hour: now.getHours() };
+  }
+  try {
+    const fmt = new Intl.DateTimeFormat("en-US", {
+      timeZone: tz,
+      weekday: "short",
+      hour: "numeric",
+      hour12: false,
+    });
+    const parts = fmt.formatToParts(now);
+    const weekdayShort = parts.find((p) => p.type === "weekday")?.value;
+    const hourStr = parts.find((p) => p.type === "hour")?.value;
+    const map = { Sun: 0, Mon: 1, Tue: 2, Wed: 3, Thu: 4, Fri: 5, Sat: 6 };
+    const weekday = map[weekdayShort];
+    // Intl returns "24" for midnight under hour12:false on some platforms.
+    const hourRaw = parseInt(hourStr, 10);
+    const hour = Number.isFinite(hourRaw) ? hourRaw % 24 : NaN;
+    if (weekday == null || !Number.isFinite(hour)) {
+      throw new Error(`unparseable Intl output for tz "${tz}"`);
+    }
+    return { weekday, hour };
+  } catch (err) {
+    logger.warn(
+      `Weekly Roundup: invalid WEEKLY_ROUNDUP_TZ "${tz}" (${err?.message || err}), falling back to host time`
+    );
+    return { weekday: now.getDay(), hour: now.getHours() };
+  }
 }
 
 async function runTick(client) {
@@ -105,13 +146,14 @@ async function runTick(client) {
     23
   );
   const now = new Date();
+  const { weekday, hour } = resolveLocalWeekdayHour(now);
 
-  if (now.getDay() !== targetWeekday) return;
+  if (weekday !== targetWeekday) return;
   // `>=` instead of strict equality: if the bot was down or the hourly tick
   // drifted past the boundary, post on the next tick within the same day
   // rather than skipping the entire week. The 6-day idempotency guard below
   // still prevents duplicates on re-tick.
-  if (now.getHours() < targetHour) return;
+  if (hour < targetHour) return;
 
   const lastPostedAtStr = process.env.WEEKLY_ROUNDUP_LAST_POSTED_AT || "";
   if (lastPostedAtStr) {
@@ -439,18 +481,39 @@ async function sendWeeklyRoundup(client, channelId, now, options = {}) {
     return;
   }
 
-  // Filter out items that we've already seen under their stable identity in
-  // a previous run. This is what catches Sonarr/Radarr quality upgrades:
-  // Jellyfin assigns the re-imported file a fresh ItemId AND a fresh
-  // DateCreated, so /Items?MinDateCreated returns it as if brand-new — but
-  // the stable key (TMDB for movies, SeriesId+S/E for episodes) matches a
-  // record from when it was originally added.
+  // Filter stages: installedAt floor → DateCreated cutoff → first-seen map.
+  // The server-side filter is MinDateLastSaved (refresh-bumped), so we
+  // enforce DateCreated here. The first-seen map catches Sonarr/Radarr
+  // quality upgrades where ItemId + DateCreated reset but the stable
+  // identity (TMDB / SeriesId+S/E) matches a prior record.
   const cutoffMs = now.getTime() - WINDOW_MS;
+  const installedAt = getInstalledAt(now.getTime());
   const beforeFilter = items.length;
+  let droppedPreInstall = 0;
+  let droppedOldDateCreated = 0;
+  let droppedAlreadySeen = 0;
   const fresh = items.filter((item) => {
+    const created = item.DateCreated ? new Date(item.DateCreated).getTime() : NaN;
+    if (Number.isFinite(created) && created < installedAt) {
+      droppedPreInstall++;
+      return false;
+    }
+    if (Number.isFinite(created) && created < cutoffMs) {
+      droppedOldDateCreated++;
+      return false;
+    }
     const firstSeenAt = recordOrGet(item, now.getTime());
-    return firstSeenAt >= cutoffMs;
+    if (firstSeenAt < cutoffMs) {
+      droppedAlreadySeen++;
+      return false;
+    }
+    return true;
   });
+  if (beforeFilter !== fresh.length) {
+    logger.debug(
+      `${logPrefix}: filtered ${beforeFilter} → ${fresh.length} items (pre-install: ${droppedPreInstall}, old DateCreated: ${droppedOldDateCreated}, already-seen: ${droppedAlreadySeen})`
+    );
+  }
   // Preserve the diagnostic counters from fetchWindowItems on the filtered
   // array (filter() drops these expando properties).
   fresh.rawCount = items.rawCount;


### PR DESCRIPTION
## Problem

Weekly roundup posted 400+ items per run with old back-catalogue mixed in (House seasons 1–8 showing up as "new this week"), and the scheduler fired in UTC inside default Docker images. Three bugs:

1. `api/jellyfin.js` sent `MinDateCreated` on `/Items` — Jellyfin doesn't support that param and silently ignored it, returning the most recent 200 items per library every run regardless of cutoff.
2. No floor against the back-catalogue on first run.
3. `now.getHours()` reads host time; Docker defaults to UTC.

## Fix

- Send `MinDateLastSaved` (the actually supported param) and paginate with early-break. Client-side `DateCreated` filter as second guard since `DateLastSaved` advances on metadata refresh too.
- Persistent `installedAt` floor in `config/dedup-roundup-state.json`, stamped at scheduler boot. Items older than `installedAt` are dropped.
- Optional `WEEKLY_ROUNDUP_TZ` env var (IANA zone) via `Intl.DateTimeFormat`, validated loudly at boot.
- Per-page error handling keeps the partial collection on transient failures, `maxTotal` cap warns when hit, missing-`DateCreated` items dropped explicitly, per-tick TZ fallback drops to debug after the boot-time warn.

Out of scope: markdown escape in titles (`\(2026\)`), role mentions for roundup/daily pick. Separate PRs.

No version bump — v1.5.5 still beta on dev.

## Verification

`node --check` clean. Live Jellyfin verification pending.

> AI-assisted documentation. Code logic manually verified.