### PR TITLE
fix(dedup): extend TTL to ~5 years so upgrades never re-notify or re-appear in roundup

### DIFF
--- a/bot/roundupFirstSeen.js
+++ b/bot/roundupFirstSeen.js
@@ -1,9 +1,8 @@
 import { PersistentMap } from "../utils/persistentMap.js";
 
-// Wider than the 7-day roundup window so an item filtered out one week is
-// still remembered the following week (avoids it re-appearing as "new" if
-// Sonarr does a second upgrade just past the 7-day mark).
-const TTL_MS = 14 * 24 * 60 * 60 * 1000;
+// Items already seen should never re-appear as "new" regardless of how many
+// Sonarr/Radarr quality upgrades happen. ~5 years is effectively permanent.
+const TTL_MS = 5 * 365 * 24 * 60 * 60 * 1000;
 
 const map = new PersistentMap("roundup-first-seen", TTL_MS, {
   validateValue: (v) => v && typeof v.firstSeenAt === "number",

--- a/jellyfinWebhook.js
+++ b/jellyfinWebhook.js
@@ -25,7 +25,7 @@ const debouncedSenders = new Map();
 // re-notifies anything in the recently-added window via the next poll/WS reconnect).
 const sentNotifications = new PersistentMap(
   "sent-notifications",
-  7 * 24 * 60 * 60 * 1000, // 7 days — survive Sonarr/Radarr upgrade cycles
+  5 * 365 * 24 * 60 * 60 * 1000, // ~5 years — items already in the library never re-notify
   { validateValue: (v) => v && typeof v.level === "number" }
 );
 
@@ -1003,7 +1003,7 @@ export async function handleJellyfinWebhook(req, res, client, pendingRequests, o
           `[DUPLICATE CHECK] ${data.ItemType} "${
             data.Name
           }" - SeriesId: ${SeriesId}, sentLevel: ${sentLevel}, currentLevel: ${currentLevel}, has debouncer: ${debouncedSenders.has(
-            SeriesId
+            seriesKey
           )}`
         );
 


### PR DESCRIPTION
## Problem

Sonarr/Radarr quality upgrades re-triggered Discord notifications and reappeared in the Weekly Roundup as new content after the dedup windows expired. `sentNotifications` expired after 7 days, `roundup-first-seen` after 14 days — an upgrade landing past those windows was treated as a brand-new item. Both maps already use stable identity keys (TMDB ID, SeriesId+S/E) that survive file replacement; the only thing broken was the TTL.

Additionally, the `[DUPLICATE CHECK]` log line checked `debouncedSenders` with the raw `SeriesId` instead of the stable `seriesKey`, so it always reported `has debouncer: false` for keyed series regardless of actual state.

## Fix

- `sentNotifications` TTL extended from 7 days to ~5 years
- `roundup-first-seen` TTL extended from 14 days to ~5 years
- `[DUPLICATE CHECK]` log now uses `seriesKey` instead of `SeriesId`

> AI-assisted documentation. Code logic manually verified.