### PR TITLE
feat: library seed, daily prune, quota errors, Seerr v3.3.0+ compatibility 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,21 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.5.6] - 2026-06-13
+## [1.5.5] - 2026-04-27
+
+### 🌍 Added
+
+- **French translation (`fr`)**: Anchorr is now fully translated into French, covering all bot messages and UI text.
 
 ### ✨ Added
 
 - **Library seed scan**: On first boot, Anchorr now scans your entire Jellyfin library and records everything that already exists, so pre-existing content never triggers a "new item" Discord notification.
 - **Daily prune scan**: A background job runs once per day to remove records for items that have been deleted from Jellyfin, keeping internal state from growing unbounded.
 - **"Re-Seed Library" button**: A new button in the Jellyfin settings section lets you manually re-run the library seed scan, e.g. after reorganizing your library.
-
----
-
-## [1.5.5] - 2026-04-27
-
-### 🌍 Added
-
-- **French translation (`fr`)**: Anchorr is now fully translated into French, covering all bot messages and UI text.
 
 ### ✨ Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.5.6] - 2026-06-13
+
+### ✨ Added
+
+- **Library seed scan**: On first boot, Anchorr now scans your entire Jellyfin library and records everything that already exists, so pre-existing content never triggers a "new item" Discord notification.
+- **Daily prune scan**: A background job runs once per day to remove records for items that have been deleted from Jellyfin, keeping internal state from growing unbounded.
+- **"Re-Seed Library" button**: A new button in the Jellyfin settings section lets you manually re-run the library seed scan, e.g. after reorganizing your library.
+
+---
+
 ## [1.5.5] - 2026-04-27
 
 ### 🌍 Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Daily prune scan**: A background job runs once per day to remove records for items that have been deleted from Jellyfin, keeping internal state from growing unbounded.
 - **"Re-Seed Library" button**: A new button in the Jellyfin settings section lets you manually re-run the library seed scan, e.g. after reorganizing your library.
 
+### 🐛 Fixed
+
+- **Quota error now shown to users**: When a `/request` hits a Jellyseerr quota limit, the bot now shows the specific reason (e.g. "Series Quota exceeded.") instead of a generic "An error occurred." message. Applies to the `/request` command, the request button, and the daily pick request button.
+- **Seerr v3.3.0+ user sync compatibility**: Jellyseerr v3.3.0 changed the user notification settings field from `discordId` (string) to `discordIds` (array). Auto-Map and Sync with Seerr now handle both formats correctly.
+
+### 🔒 Security
+
+- **form-data bumped to 4.0.6** (GHSA-hmw2-7cc7-3qxx): Resolves a prototype pollution vulnerability in a transitive dependency.
+
 ---
 
 ## [1.5.5] - 2026-06-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.5.5] - 2026-04-27
-
-### 🌍 Added
-
-- **French translation (`fr`)**: Anchorr is now fully translated into French, covering all bot messages and UI text.
+## [1.5.6] - 2026-06-13
 
 ### ✨ Added
 
 - **Library seed scan**: On first boot, Anchorr now scans your entire Jellyfin library and records everything that already exists, so pre-existing content never triggers a "new item" Discord notification.
 - **Daily prune scan**: A background job runs once per day to remove records for items that have been deleted from Jellyfin, keeping internal state from growing unbounded.
 - **"Re-Seed Library" button**: A new button in the Jellyfin settings section lets you manually re-run the library seed scan, e.g. after reorganizing your library.
+
+---
+
+## [1.5.5] - 2026-04-27
+
+### 🌍 Added
+
+- **French translation (`fr`)**: Anchorr is now fully translated into French, covering all bot messages and UI text.
 
 ### ✨ Added
 

--- a/api/jellyfin.js
+++ b/api/jellyfin.js
@@ -531,6 +531,59 @@ export async function fetchRecentlyAdded(
   }
 }
 
+const FETCH_ALL_ITEMS_PAGE_SIZE = 200;
+
+/**
+ * Fetch every Movie/Series/Season/Episode under a library (ParentId),
+ * paginated via StartIndex/Limit with no upper cap on total items.
+ * Used for the one-time library seed scan and the daily prune scan —
+ * unlike fetchRecentlyAdded, this must see the *entire* library, not
+ * just recently added items.
+ */
+export async function fetchAllLibraryItems(apiKey, baseUrl, parentId) {
+  const safeBase = new URL(baseUrl);
+  safeBase.pathname = safeBase.pathname.replace(/\/$/, "") + "/Items";
+  const url = safeBase.href;
+  const baseParams = {
+    Fields: "ProviderIds,SeriesName,SeasonName,IndexNumber,ParentIndexNumber,AncestorIds",
+    IncludeItemTypes: "Movie,Series,Season,Episode",
+    Recursive: true,
+    SortBy: "SortName",
+    SortOrder: "Ascending",
+    Limit: FETCH_ALL_ITEMS_PAGE_SIZE,
+    ParentId: parentId,
+  };
+
+  const collected = [];
+  let startIndex = 0;
+  while (true) {
+    const params = { ...baseParams, StartIndex: startIndex };
+    let page;
+    try {
+      const response = await axios.get(url, {
+        headers: { "X-MediaBrowser-Token": apiKey },
+        params,
+        timeout: 15000,
+      });
+      page = response.data?.Items || [];
+    } catch (err) {
+      logger.warn(
+        `fetchAllLibraryItems: page at StartIndex=${startIndex} (parent ${parentId}) failed (${err?.message || err}); returning ${collected.length} items collected so far`
+      );
+      break;
+    }
+    if (page.length === 0) break;
+    collected.push(...page);
+    if (page.length < FETCH_ALL_ITEMS_PAGE_SIZE) break;
+    startIndex += FETCH_ALL_ITEMS_PAGE_SIZE;
+  }
+
+  logger.debug(
+    `fetchAllLibraryItems: fetched ${collected.length} items for parent ${parentId}`
+  );
+  return collected;
+}
+
 /**
  * Fetch detailed information about a specific item
  * @param {string} itemId - Jellyfin item ID

--- a/api/jellyfin.js
+++ b/api/jellyfin.js
@@ -539,6 +539,9 @@ const FETCH_ALL_ITEMS_PAGE_SIZE = 200;
  * Used for the one-time library seed scan and the daily prune scan —
  * unlike fetchRecentlyAdded, this must see the *entire* library, not
  * just recently added items.
+ *
+ * Returns { items: object[], complete: boolean }; complete is false if a
+ * page fetch failed partway through.
  */
 export async function fetchAllLibraryItems(apiKey, baseUrl, parentId) {
   const safeBase = new URL(baseUrl);
@@ -556,6 +559,7 @@ export async function fetchAllLibraryItems(apiKey, baseUrl, parentId) {
 
   const collected = [];
   let startIndex = 0;
+  let complete = true;
   while (true) {
     const params = { ...baseParams, StartIndex: startIndex };
     let page;
@@ -568,8 +572,9 @@ export async function fetchAllLibraryItems(apiKey, baseUrl, parentId) {
       page = response.data?.Items || [];
     } catch (err) {
       logger.warn(
-        `fetchAllLibraryItems: page at StartIndex=${startIndex} (parent ${parentId}) failed (${err?.message || err}); returning ${collected.length} items collected so far`
+        `fetchAllLibraryItems: page at StartIndex=${startIndex} (parent ${parentId}) failed (${err?.message || err}); returning ${collected.length} items collected so far (incomplete)`
       );
+      complete = false;
       break;
     }
     if (page.length === 0) break;
@@ -579,9 +584,9 @@ export async function fetchAllLibraryItems(apiKey, baseUrl, parentId) {
   }
 
   logger.debug(
-    `fetchAllLibraryItems: fetched ${collected.length} items for parent ${parentId}`
+    `fetchAllLibraryItems: fetched ${collected.length} items for parent ${parentId} (complete: ${complete})`
   );
-  return collected;
+  return { items: collected, complete };
 }
 
 /**

--- a/api/jellyfin.js
+++ b/api/jellyfin.js
@@ -473,8 +473,17 @@ export async function fetchRecentlyAdded(
           params,
           timeout: 10000,
         });
-        page = response.data?.Items || [];
+        const body = response.data;
+        if (!body || !Array.isArray(body.Items)) {
+          logger.warn(
+            `fetchRecentlyAdded: unexpected response shape from Jellyfin (StartIndex=${startIndex}) — stopping pagination`
+          );
+          stopReason = "page-error";
+          break;
+        }
+        page = body.Items;
       } catch (err) {
+        if (!err?.isAxiosError) throw err;
         // Per-page failure: keep what we have, surface a warning, stop.
         // Returning the partial set is better than throwing the whole call
         // away — the caller's downstream filters tolerate fewer items

--- a/api/jellyfin.js
+++ b/api/jellyfin.js
@@ -569,8 +569,17 @@ export async function fetchAllLibraryItems(apiKey, baseUrl, parentId) {
         params,
         timeout: 15000,
       });
-      page = response.data?.Items || [];
+      const body = response.data;
+      if (!body || !Array.isArray(body.Items)) {
+        logger.warn(
+          `fetchAllLibraryItems: unexpected response shape from Jellyfin (parent ${parentId}, StartIndex=${startIndex}) — treating as incomplete`
+        );
+        complete = false;
+        break;
+      }
+      page = body.Items;
     } catch (err) {
+      if (!err?.isAxiosError) throw err;
       logger.warn(
         `fetchAllLibraryItems: page at StartIndex=${startIndex} (parent ${parentId}) failed (${err?.message || err}); returning ${collected.length} items collected so far (incomplete)`
       );

--- a/app.js
+++ b/app.js
@@ -10,6 +10,8 @@ import { handleJellyfinWebhook } from "./jellyfinWebhook.js";
 import { configTemplate } from "./lib/config.js";
 import { sendDailyRandomPick } from "./bot/dailyPick.js";
 import { sendWeeklyRoundupTest } from "./bot/weeklyRoundup.js";
+import { seedLibrary } from "./jellyfin/librarySeeder.js";
+import { pruneLibrary } from "./jellyfin/libraryPruner.js";
 
 // ESM __dirname equivalent
 const __filename = fileURLToPath(import.meta.url);
@@ -1070,6 +1072,7 @@ logger.info("Web server configured successfully");
 // --- START THE SERVER ---
 // This single `app.listen` call handles both modes.
 let server;
+let libraryPruneTimer;
 
 function startServer() {
   // Check volume configuration early
@@ -1143,7 +1146,21 @@ function startServer() {
     } catch (e) {
       logger.error("Error during auto-start check:", e?.message || e);
     }
+
+    // One-time library seed: pre-populate the dedup store with everything
+    // that already exists in Jellyfin so pre-existing content never
+    // triggers a "new item" Discord notification. Runs async — webhook/
+    // poller/websocket are already listening and handle items normally
+    // while this is in progress.
+    if (process.env.LIBRARY_SEEDED !== "true") {
+      seedLibrary();
+    }
   });
+
+  const LIBRARY_PRUNE_INTERVAL_MS = 24 * 60 * 60 * 1000;
+  libraryPruneTimer = setInterval(() => {
+    pruneLibrary();
+  }, LIBRARY_PRUNE_INTERVAL_MS);
 
   server.on("error", (err) => {
     if (err.code === "EADDRINUSE") {
@@ -1163,6 +1180,7 @@ function startServer() {
 
 // Keep the process alive
 process.on("SIGTERM", () => {
+  clearInterval(libraryPruneTimer);
   logger.info("SIGTERM signal received: closing HTTP server");
   server.close(() => {
     logger.info("HTTP server closed");
@@ -1171,6 +1189,7 @@ process.on("SIGTERM", () => {
 });
 
 process.on("SIGINT", () => {
+  clearInterval(libraryPruneTimer);
   logger.info("SIGINT signal received: closing HTTP server");
   server.close(() => {
     logger.info("HTTP server closed");

--- a/app.js
+++ b/app.js
@@ -1153,13 +1153,17 @@ function startServer() {
     // poller/websocket are already listening and handle items normally
     // while this is in progress.
     if (process.env.LIBRARY_SEEDED !== "true") {
-      seedLibrary();
+      seedLibrary().catch((err) =>
+        logger.error(`librarySeeder: unexpected rejection on boot (${err?.message || err})`)
+      );
     }
   });
 
   const LIBRARY_PRUNE_INTERVAL_MS = 24 * 60 * 60 * 1000;
   libraryPruneTimer = setInterval(() => {
-    pruneLibrary();
+    pruneLibrary().catch((err) =>
+      logger.error(`libraryPruner: unexpected rejection in prune cycle (${err?.message || err})`)
+    );
   }, LIBRARY_PRUNE_INTERVAL_MS);
 
   server.on("error", (err) => {

--- a/bot/interactions.js
+++ b/bot/interactions.js
@@ -23,6 +23,30 @@ const getSeerrUrl = () => getSeerrApiUrl(process.env.SEERR_URL || "");
 const getSeerrApiKey = () => process.env.SEERR_API_KEY;
 const getTmdbApiKey = () => process.env.TMDB_API_KEY;
 
+// Returns a user-facing error message for a failed Seerr request.
+function getSeerrErrorMessage(err) {
+  if (err.response) {
+    const status = err.response.status;
+    const msg = err.response.data?.message || "";
+    if (/quota/i.test(msg)) {
+      return `⚠️ ${msg} You've reached your request limit — contact an admin if you think this is a mistake.`;
+    }
+    if (status === 401 || status === 403) {
+      return "⚠️ Request failed: authentication error. Check the bot's API key configuration.";
+    }
+    if (status >= 500) {
+      return "⚠️ Seerr returned a server error. Try again later.";
+    }
+    if (msg) {
+      return `⚠️ Seerr error: ${msg}`;
+    }
+  }
+  if (err.code === "ECONNREFUSED" || err.code === "ETIMEDOUT" || err.code === "ENOTFOUND") {
+    return "⚠️ Could not reach Seerr. Check that your Seerr URL is correct and reachable.";
+  }
+  return `⚠️ An error occurred: ${err.message || "unknown error"}`;
+}
+
 // ----------------- COMMON SEARCH LOGIC -----------------
 async function handleSearchOrRequest(
   interaction,
@@ -266,21 +290,7 @@ async function handleSearchOrRequest(
   } catch (err) {
     logger.error("Error in handleSearchOrRequest:", err);
 
-    let errorMessage = "⚠️ An error occurred.";
-    if (err.response) {
-      const status = err.response.status;
-      if (status === 401 || status === 403) {
-        errorMessage = "⚠️ Request failed: You might have exceeded your quota or don't have permission.";
-      } else if (status >= 500) {
-        errorMessage = "⚠️ Seerr returned a server error. Try again later.";
-      } else if (err.response.data?.message) {
-        errorMessage = `⚠️ Seerr error: ${err.response.data.message}`;
-      }
-    } else if (err.code === "ECONNREFUSED" || err.code === "ETIMEDOUT" || err.code === "ENOTFOUND") {
-      errorMessage = "⚠️ Could not reach Seerr. Check that your Seerr URL is correct and reachable.";
-    } else if (err.message) {
-      errorMessage = `⚠️ Error: ${err.message}`;
-    }
+    const errorMessage = getSeerrErrorMessage(err);
 
     if (isPrivateMode) {
       await interaction.editReply({
@@ -762,19 +772,7 @@ export function registerInteractions(client) {
           await interaction.editReply({ embeds: [embed], components });
         } catch (err) {
           logger.error("Button request error:", err);
-          let userMessage = "⚠️ I could not send the request.";
-          if (err.response) {
-            const status = err.response.status;
-            if (status === 401 || status === 403) {
-              userMessage = "⚠️ Seerr authentication failed. Check your API key in the bot configuration.";
-            } else if (status >= 500) {
-              userMessage = "⚠️ Seerr returned a server error. Try again later.";
-            } else if (err.response.data?.message) {
-              userMessage = `⚠️ Seerr error: ${err.response.data.message}`;
-            }
-          } else if (err.code === "ECONNREFUSED" || err.code === "ETIMEDOUT" || err.code === "ENOTFOUND") {
-            userMessage = "⚠️ Could not reach Seerr. Check that your Seerr URL is correct and reachable.";
-          }
+          const userMessage = getSeerrErrorMessage(err);
           try {
             await interaction.followUp({
               content: userMessage,
@@ -1106,7 +1104,7 @@ export function registerInteractions(client) {
         } catch (err) {
           logger.error("Daily random pick request error:", err);
           await interaction.followUp({
-            content: "⚠️ Error processing request.",
+            content: getSeerrErrorMessage(err),
             flags: 64,
           });
         }

--- a/jellyfin/libraryPruner.js
+++ b/jellyfin/libraryPruner.js
@@ -25,11 +25,17 @@ export async function pruneLibrary() {
     const currentKeys = new Set();
 
     for (const lib of libraries) {
-      const items = await jellyfinApi.fetchAllLibraryItems(
+      const { items, complete } = await jellyfinApi.fetchAllLibraryItems(
         apiKey,
         baseUrl,
         lib.ItemId
       );
+      if (!complete) {
+        logger.error(
+          `libraryPruner: incomplete fetch for library "${lib.Name}" — aborting prune run, no keys removed (will retry next cycle)`
+        );
+        return;
+      }
       for (const item of items) {
         for (const key of deriveSeedKeys(item)) currentKeys.add(key);
       }

--- a/jellyfin/libraryPruner.js
+++ b/jellyfin/libraryPruner.js
@@ -1,0 +1,52 @@
+import * as jellyfinApi from "../api/jellyfin.js";
+import { fetchLibraryMap, deduplicator } from "./libraryResolver.js";
+import { deriveSeedKeys } from "./librarySeeder.js";
+import logger from "../utils/logger.js";
+
+/**
+ * Daily background scan: re-enumerates every Jellyfin library and removes
+ * dedup-store keys for items that no longer exist (i.e. were deleted from
+ * Jellyfin). Only touches movie:/series: identity keys — the same format
+ * produced by buildIdentityKey()/deriveSeedKeys() — so unrelated dedup
+ * entries (e.g. raw id: fallback keys for un-identified items, which this
+ * scan also produces and thus also covers) are handled consistently.
+ */
+export async function pruneLibrary() {
+  const apiKey = process.env.JELLYFIN_API_KEY;
+  const baseUrl = process.env.JELLYFIN_BASE_URL;
+  if (!apiKey || !baseUrl) {
+    logger.debug("libraryPruner: Jellyfin not configured — skipping prune");
+    return;
+  }
+
+  logger.info("libraryPruner: starting daily prune scan...");
+  try {
+    const { libraries } = await fetchLibraryMap();
+    const currentKeys = new Set();
+
+    for (const lib of libraries) {
+      const items = await jellyfinApi.fetchAllLibraryItems(
+        apiKey,
+        baseUrl,
+        lib.ItemId
+      );
+      for (const item of items) {
+        for (const key of deriveSeedKeys(item)) currentKeys.add(key);
+      }
+    }
+
+    const removed = deduplicator.store.prune(
+      (key) =>
+        (key.startsWith("movie:") ||
+          key.startsWith("series:") ||
+          key.startsWith("id:")) &&
+        !currentKeys.has(key)
+    );
+
+    logger.info(
+      `libraryPruner: prune complete — removed ${removed} stale identity key(s)`
+    );
+  } catch (err) {
+    logger.error(`libraryPruner: prune failed (${err?.message || err})`);
+  }
+}

--- a/jellyfin/libraryPruner.js
+++ b/jellyfin/libraryPruner.js
@@ -1,27 +1,39 @@
 import * as jellyfinApi from "../api/jellyfin.js";
 import { fetchLibraryMap, deduplicator } from "./libraryResolver.js";
-import { deriveSeedKeys } from "./librarySeeder.js";
+import { deriveSeedKeys, isScanInProgress } from "./librarySeeder.js";
 import logger from "../utils/logger.js";
 
 /**
  * Daily background scan: re-enumerates every Jellyfin library and removes
  * dedup-store keys for items that no longer exist (i.e. were deleted from
- * Jellyfin). Only touches movie:/series: identity keys — the same format
- * produced by buildIdentityKey()/deriveSeedKeys() — so unrelated dedup
- * entries (e.g. raw id: fallback keys for un-identified items, which this
- * scan also produces and thus also covers) are handled consistently.
+ * Jellyfin). Re-asserts keys for surviving items so their TTL is refreshed
+ * and long-lived library items stay suppressed indefinitely. Only touches
+ * movie:/series:/id: identity keys — the same format produced by
+ * buildIdentityKey()/deriveSeedKeys().
+ *
+ * Aborts without removing any keys if any library page fetch is incomplete,
+ * to avoid falsely expiring keys due to a transient Jellyfin outage.
  */
 export async function pruneLibrary() {
+  if (isScanInProgress()) {
+    logger.warn("libraryPruner: seed scan in progress — skipping prune cycle");
+    return;
+  }
+
   const apiKey = process.env.JELLYFIN_API_KEY;
   const baseUrl = process.env.JELLYFIN_BASE_URL;
   if (!apiKey || !baseUrl) {
-    logger.debug("libraryPruner: Jellyfin not configured — skipping prune");
+    logger.warn("libraryPruner: Jellyfin not configured — skipping prune");
     return;
   }
 
   logger.info("libraryPruner: starting daily prune scan...");
   try {
-    const { libraries } = await fetchLibraryMap();
+    const result = await fetchLibraryMap();
+    const libraries = result?.libraries;
+    if (!Array.isArray(libraries)) {
+      throw new Error("fetchLibraryMap returned unexpected shape — cannot prune");
+    }
     const currentKeys = new Set();
 
     for (const lib of libraries) {
@@ -41,6 +53,12 @@ export async function pruneLibrary() {
       }
     }
 
+    // Re-assert surviving keys so their TTL resets — without this, seeded
+    // keys expire after 7 days and old items would be announced as new again.
+    for (const key of currentKeys) {
+      deduplicator.store.set(key, true);
+    }
+
     const removed = deduplicator.store.prune(
       (key) =>
         (key.startsWith("movie:") ||
@@ -49,8 +67,10 @@ export async function pruneLibrary() {
         !currentKeys.has(key)
     );
 
+    deduplicator.store.flush();
+
     logger.info(
-      `libraryPruner: prune complete — removed ${removed} stale identity key(s)`
+      `libraryPruner: prune complete — refreshed ${currentKeys.size} key(s), removed ${removed} stale identity key(s)`
     );
   } catch (err) {
     logger.error(`libraryPruner: prune failed (${err?.message || err})`);

--- a/jellyfin/libraryPruner.js
+++ b/jellyfin/libraryPruner.js
@@ -1,6 +1,6 @@
 import * as jellyfinApi from "../api/jellyfin.js";
 import { fetchLibraryMap, deduplicator } from "./libraryResolver.js";
-import { deriveSeedKeys, isScanInProgress } from "./librarySeeder.js";
+import { deriveSeedKeys, isScanInProgress, setScanInProgress } from "./librarySeeder.js";
 import logger from "../utils/logger.js";
 
 /**
@@ -27,6 +27,7 @@ export async function pruneLibrary() {
     return;
   }
 
+  setScanInProgress(true);
   logger.info("libraryPruner: starting daily prune scan...");
   try {
     const result = await fetchLibraryMap();
@@ -74,5 +75,7 @@ export async function pruneLibrary() {
     );
   } catch (err) {
     logger.error(`libraryPruner: prune failed (${err?.message || err})`);
+  } finally {
+    setScanInProgress(false);
   }
 }

--- a/jellyfin/librarySeeder.js
+++ b/jellyfin/librarySeeder.js
@@ -61,11 +61,16 @@ export async function seedLibrary() {
     let totalKeys = 0;
 
     for (const lib of libraries) {
-      const items = await jellyfinApi.fetchAllLibraryItems(
+      const { items, complete } = await jellyfinApi.fetchAllLibraryItems(
         apiKey,
         baseUrl,
         lib.ItemId
       );
+      if (!complete) {
+        throw new Error(
+          `incomplete fetch for library "${lib.Name}" — aborting seed`
+        );
+      }
       for (const item of items) {
         for (const key of deriveSeedKeys(item)) {
           deduplicator.store.set(key, true);

--- a/jellyfin/librarySeeder.js
+++ b/jellyfin/librarySeeder.js
@@ -1,0 +1,95 @@
+import * as jellyfinApi from "../api/jellyfin.js";
+import {
+  fetchLibraryMap,
+  buildIdentityKey,
+  deduplicator,
+} from "./libraryResolver.js";
+import { updateConfig } from "../utils/configFile.js";
+import logger from "../utils/logger.js";
+
+/**
+ * Builds every identity key that webhook/poller dedup might check for a
+ * given Jellyfin API item. For episodes, this includes the series-level
+ * and season-level keys in addition to the episode-level key, so a webhook
+ * for a pre-existing episode is suppressed at any granularity.
+ */
+export function deriveSeedKeys(item) {
+  const keys = [];
+  const itemKey = buildIdentityKey(item);
+  if (itemKey) keys.push(itemKey);
+
+  if (item.Type === "Episode") {
+    const seriesKeyPart = item.ProviderIds?.Tmdb
+      ? `tmdb:${item.ProviderIds.Tmdb}`
+      : item.SeriesId
+      ? `id:${item.SeriesId}`
+      : item.SeriesName
+      ? `name:${item.SeriesName}`
+      : null;
+
+    if (seriesKeyPart) {
+      keys.push(`series:${seriesKeyPart}`);
+      if (item.ParentIndexNumber != null) {
+        keys.push(`series:${seriesKeyPart}:s${item.ParentIndexNumber}`);
+      }
+    }
+  }
+
+  return keys;
+}
+
+/**
+ * One-time (or manually re-triggered) scan of every Jellyfin library.
+ * Pre-populates the existing dedup store so webhooks for pre-existing
+ * content are never treated as "new". On success, persists
+ * LIBRARY_SEEDED=true to config.json. On failure, leaves the flag unset
+ * so the caller retries on the next process start.
+ */
+export async function seedLibrary() {
+  const apiKey = process.env.JELLYFIN_API_KEY;
+  const baseUrl = process.env.JELLYFIN_BASE_URL;
+  if (!apiKey || !baseUrl) {
+    logger.warn(
+      "librarySeeder: JELLYFIN_API_KEY/JELLYFIN_BASE_URL not configured — skipping library seed"
+    );
+    return;
+  }
+
+  logger.info("librarySeeder: starting library seed scan...");
+  try {
+    const { libraries } = await fetchLibraryMap();
+    let totalKeys = 0;
+
+    for (const lib of libraries) {
+      const items = await jellyfinApi.fetchAllLibraryItems(
+        apiKey,
+        baseUrl,
+        lib.ItemId
+      );
+      for (const item of items) {
+        for (const key of deriveSeedKeys(item)) {
+          deduplicator.store.set(key, true);
+          totalKeys++;
+        }
+      }
+      logger.info(
+        `librarySeeder: seeded ${items.length} items from library "${lib.Name}"`
+      );
+    }
+
+    deduplicator.store.flush();
+
+    if (!updateConfig({ LIBRARY_SEEDED: "true" })) {
+      throw new Error("failed to persist LIBRARY_SEEDED flag to config.json");
+    }
+    process.env.LIBRARY_SEEDED = "true";
+
+    logger.info(
+      `librarySeeder: seed complete — ${totalKeys} identity keys stored across ${libraries.length} libraries`
+    );
+  } catch (err) {
+    logger.error(
+      `librarySeeder: seed failed (${err?.message || err}) — LIBRARY_SEEDED left unset, will retry on next start`
+    );
+  }
+}

--- a/jellyfin/librarySeeder.js
+++ b/jellyfin/librarySeeder.js
@@ -14,6 +14,10 @@ export function isScanInProgress() {
   return scanInProgress;
 }
 
+export function setScanInProgress(value) {
+  scanInProgress = value;
+}
+
 /**
  * Builds every identity key that webhook/poller dedup might check for a
  * given Jellyfin API item. For episodes, this includes the series-level

--- a/jellyfin/librarySeeder.js
+++ b/jellyfin/librarySeeder.js
@@ -7,6 +7,13 @@ import {
 import { updateConfig } from "../utils/configFile.js";
 import logger from "../utils/logger.js";
 
+// Shared flag: prevents concurrent seed and prune scans from running simultaneously.
+let scanInProgress = false;
+
+export function isScanInProgress() {
+  return scanInProgress;
+}
+
 /**
  * Builds every identity key that webhook/poller dedup might check for a
  * given Jellyfin API item. For episodes, this includes the series-level
@@ -46,6 +53,11 @@ export function deriveSeedKeys(item) {
  * so the caller retries on the next process start.
  */
 export async function seedLibrary() {
+  if (scanInProgress) {
+    logger.warn("librarySeeder: scan already in progress — skipping");
+    return;
+  }
+
   const apiKey = process.env.JELLYFIN_API_KEY;
   const baseUrl = process.env.JELLYFIN_BASE_URL;
   if (!apiKey || !baseUrl) {
@@ -55,9 +67,14 @@ export async function seedLibrary() {
     return;
   }
 
+  scanInProgress = true;
   logger.info("librarySeeder: starting library seed scan...");
   try {
-    const { libraries } = await fetchLibraryMap();
+    const result = await fetchLibraryMap();
+    const libraries = result?.libraries;
+    if (!Array.isArray(libraries)) {
+      throw new Error("fetchLibraryMap returned unexpected shape — cannot seed");
+    }
     let totalKeys = 0;
 
     for (const lib of libraries) {
@@ -96,5 +113,7 @@ export async function seedLibrary() {
     logger.error(
       `librarySeeder: seed failed (${err?.message || err}) — LIBRARY_SEEDED left unset, will retry on next start`
     );
+  } finally {
+    scanInProgress = false;
   }
 }

--- a/lib/config.js
+++ b/lib/config.js
@@ -65,4 +65,5 @@ export const configTemplate = {
   WEEKLY_ROUNDUP_EMBED_COLOR: "",
   WEEKLY_ROUNDUP_LAST_POSTED_AT: "",
   WEEKLY_ROUNDUP_ROLE_ID: "",
+  LIBRARY_SEEDED: "false",
 };

--- a/locales/en.json
+++ b/locales/en.json
@@ -127,6 +127,8 @@
     "jellyfin_api_key_help": "API key for your Jellyfin server. You can generate one in Jellyfin Dashboard → Administration → API Keys. This is required for loading libraries and enhanced features.",
     "test_endpoint": "Test Endpoint",
     "test_endpoint_help": "Testing the endpoint successfully will automatically populate the Jellyfin Server ID field.",
+    "reseed_library": "Re-Seed Library",
+    "reseed_library_help": "Re-scans your entire Jellyfin library and marks all current items as \"already known\", so they won't trigger Discord notifications. Use this if you've reorganized your library or if old items are incorrectly being announced as new.",
     "jellyfin_server_id": "Jellyfin Server ID",
     "jellyfin_server_id_help": "Used for redirecting to the correct path of your Jellyfin server media page when using the \"Watch Now\" button. You can find this in your Jellyfin URL when viewing the page of any movie or show from your library.",
     "notification_testing_title": "Notification Testing",

--- a/locales/template.json
+++ b/locales/template.json
@@ -127,6 +127,8 @@
     "jellyfin_api_key_help": "",
     "test_endpoint": "",
     "test_endpoint_help": "",
+    "reseed_library": "",
+    "reseed_library_help": "",
     "jellyfin_server_id": "",
     "jellyfin_server_id_help": "",
     "notification_testing_title": "",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "discord.js": "^14.22.1",
         "express": "^4.18.2",
         "express-rate-limit": "^7.1.5",
-        "joi": "^18.0.2",
+        "joi": "^18.2.1",
         "jsonwebtoken": "^9.0.2",
         "lodash.debounce": "^4.0.8",
         "node-cache": "^5.1.2",
@@ -1150,9 +1150,9 @@
       }
     },
     "node_modules/joi": {
-      "version": "18.0.2",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-18.0.2.tgz",
-      "integrity": "sha512-RuCOQMIt78LWnktPoeBL0GErkNaJPTBGcYuyaBvUOQSpcpcLfWrHPPihYdOGbV5pam9VTWbeoF7TsGiHugcjGA==",
+      "version": "18.2.1",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-18.2.1.tgz",
+      "integrity": "sha512-2/OKlogiESf2Nh3TFCrRjrr9z1DRHeW0I+KReF67+4J0Ns+8hBtHRmoWAZ2OFU6I5+TWLEe6sVlSdXPjHm5UbQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/address": "^5.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -928,16 +928,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -1047,9 +1047,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anchorr",
-  "version": "1.5.6",
+  "version": "1.5.5",
   "main": "app.js",
   "scripts": {
     "start": "node app.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anchorr",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "main": "app.js",
   "scripts": {
     "start": "node app.js",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "discord.js": "^14.22.1",
     "express": "^4.18.2",
     "express-rate-limit": "^7.1.5",
-    "joi": "^18.0.2",
+    "joi": "^18.2.1",
     "jsonwebtoken": "^9.0.2",
     "lodash.debounce": "^4.0.8",
     "node-cache": "^5.1.2",

--- a/routes/jellyfinRoutes.js
+++ b/routes/jellyfinRoutes.js
@@ -5,8 +5,30 @@ import { isMaskedValue } from "../utils/configSanitize.js";
 import { TIMEOUTS } from "../lib/constants.js";
 import { libraryCache } from "../jellyfinWebhook.js";
 import logger from "../utils/logger.js";
+import { seedLibrary } from "../jellyfin/librarySeeder.js";
+import { updateConfig } from "../utils/configFile.js";
 
 const router = Router();
+
+// Resets the LIBRARY_SEEDED flag and re-runs the full library seed scan.
+// Fire-and-forget: the scan can take a while for large libraries, so this
+// responds immediately and the scan continues in the background.
+router.post("/seed/reset", authenticateToken, async (_req, res) => {
+  if (!updateConfig({ LIBRARY_SEEDED: "false" })) {
+    return res.status(500).json({
+      success: false,
+      message: "Failed to update config.json.",
+    });
+  }
+  process.env.LIBRARY_SEEDED = "false";
+
+  seedLibrary(); // fire and forget — logs its own progress/result
+
+  res.json({
+    success: true,
+    message: "Library re-seed started in the background. Check the logs for progress.",
+  });
+});
 
 function isAllowedUrl(url) {
   try {

--- a/routes/jellyfinRoutes.js
+++ b/routes/jellyfinRoutes.js
@@ -22,7 +22,9 @@ router.post("/seed/reset", authenticateToken, async (_req, res) => {
   }
   process.env.LIBRARY_SEEDED = "false";
 
-  seedLibrary(); // fire and forget — logs its own progress/result
+  seedLibrary().catch((err) =>
+    logger.error(`librarySeeder: unexpected rejection from re-seed (${err?.message || err})`)
+  );
 
   res.json({
     success: true,

--- a/routes/seerrRoutes.js
+++ b/routes/seerrRoutes.js
@@ -225,25 +225,31 @@ router.get("/seerr/auto-map-preview", authenticateToken, async (_req, res) => {
             `${baseUrl}/user/${user.id}/settings/notifications`,
             { headers: { "X-Api-Key": apiKey }, timeout: TIMEOUTS.SEERR_API }
           );
-          return { user, discordId: settingsRes.data?.discordId || null };
+          // Seerr v3.3.0+ uses discordIds (array); fall back to legacy discordId (string)
+          const raw = settingsRes.data?.discordIds ?? settingsRes.data?.discordId ?? null;
+          const discordIds = Array.isArray(raw) ? raw : (raw ? [raw] : []);
+          return { user, discordIds };
         })
       );
 
       for (const result of results) {
-        if (result.status !== "fulfilled" || !result.value.discordId) continue;
-        const { user, discordId } = result.value;
-        if (mappedDiscordIds.has(discordId)) continue;
+        if (result.status !== "fulfilled" || result.value.discordIds.length === 0) continue;
+        const { user, discordIds } = result.value;
 
         let avatar = user.avatar || null;
         if (avatar && !avatar.startsWith("http")) {
           avatar = `${normalizeSeerrUrl(seerrUrl)}${avatar}`;
         }
-        candidates.push({
-          seerrUserId: user.id,
-          seerrDisplayName: user.displayName || user.username || `User ${user.id}`,
-          seerrAvatar: avatar,
-          discordId,
-        });
+
+        for (const discordId of discordIds) {
+          if (!/^\d{17,20}$/.test(discordId) || mappedDiscordIds.has(discordId)) continue;
+          candidates.push({
+            seerrUserId: user.id,
+            seerrDisplayName: user.displayName || user.username || `User ${user.id}`,
+            seerrAvatar: avatar,
+            discordId,
+          });
+        }
       }
     }
 
@@ -302,7 +308,10 @@ router.get("/seerr/sync-preview", authenticateToken, async (_req, res) => {
             `${baseUrl}/user/${mapping.seerrUserId}/settings/notifications`,
             { headers: { "X-Api-Key": apiKey }, timeout: TIMEOUTS.SEERR_API }
           );
-          return { mapping, currentDiscordId: settingsRes.data?.discordId || null };
+          // Seerr v3.3.0+ uses discordIds (array); fall back to legacy discordId (string)
+          const raw = settingsRes.data?.discordIds ?? settingsRes.data?.discordId ?? null;
+          const currentDiscordIds = Array.isArray(raw) ? raw : (raw ? [raw] : []);
+          return { mapping, currentDiscordIds };
         })
       );
 
@@ -330,16 +339,16 @@ router.get("/seerr/sync-preview", authenticateToken, async (_req, res) => {
           continue;
         }
 
-        const { currentDiscordId } = result.value;
-        if (currentDiscordId !== mapping.discordUserId) {
+        const { currentDiscordIds } = result.value;
+        if (!currentDiscordIds.includes(mapping.discordUserId)) {
           stale.push({
             discordId: mapping.discordUserId,
             seerrUserId: mapping.seerrUserId,
             seerrDisplayName: mapping.seerrDisplayName || null,
             discordUsername: mapping.discordUsername || null,
             discordDisplayName: mapping.discordDisplayName || null,
-            currentSeerrDiscordId: currentDiscordId,
-            reason: currentDiscordId ? "discord_id_changed" : "discord_unlinked",
+            currentSeerrDiscordId: currentDiscordIds[0] || null,
+            reason: currentDiscordIds.length > 0 ? "discord_id_changed" : "discord_unlinked",
           });
         }
       }

--- a/web/index.html
+++ b/web/index.html
@@ -524,6 +524,16 @@
                         </div>
                       </div>
                       <div class="form-group">
+                        <button type="button" id="reseed-library-btn" class="btn btn-secondary" style="padding: 0.5rem 1rem;" data-i18n="config.reseed_library">Re-Seed Library</button>
+                        <span
+                          id="reseed-library-status"
+                          style="margin-left: 1rem;"
+                        ></span>
+                        <div class="form-text" style="margin-top: 0.5rem;" data-i18n="config.reseed_library_help">
+                          Re-scans your entire Jellyfin library and marks all current items as "already known", so they won't trigger Discord notifications. Use this if you've reorganized your library or if old items are incorrectly being announced as new.
+                        </div>
+                      </div>
+                      <div class="form-group">
                         <label for="JELLYFIN_SERVER_ID" data-i18n="config.jellyfin_server_id"
                           >Jellyfin Server ID</label
                         >

--- a/web/script.js
+++ b/web/script.js
@@ -1390,6 +1390,40 @@ document.addEventListener("DOMContentLoaded", async () => {
     });
   }
 
+  // Re-Seed Library Button
+  const reseedLibraryBtn = document.getElementById("reseed-library-btn");
+  const reseedLibraryStatus = document.getElementById("reseed-library-status");
+  if (reseedLibraryBtn) {
+    reseedLibraryBtn.addEventListener("click", async () => {
+      reseedLibraryBtn.disabled = true;
+      const originalText = reseedLibraryBtn.innerHTML;
+      reseedLibraryBtn.innerHTML = '<i class="bi bi-hourglass-split"></i> Starting...';
+      reseedLibraryStatus.textContent = "";
+
+      try {
+        const response = await fetch("/api/seed/reset", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+        });
+
+        const result = await response.json();
+
+        if (response.ok && result.success) {
+          reseedLibraryStatus.textContent = result.message;
+          reseedLibraryStatus.style.color = "var(--green)";
+        } else {
+          throw new Error(result.message || "Failed to start re-seed");
+        }
+      } catch (error) {
+        reseedLibraryStatus.textContent = error.message;
+        reseedLibraryStatus.style.color = "#f38ba8";
+      } finally {
+        reseedLibraryBtn.innerHTML = originalText;
+        reseedLibraryBtn.disabled = false;
+      }
+    });
+  }
+
   // Fetch and display Jellyfin libraries for notifications
   const fetchLibrariesBtn = document.getElementById("fetch-libraries-btn");
   const fetchLibrariesStatus = document.getElementById(


### PR DESCRIPTION
## Summary

- On first boot, scans the entire Jellyfin library and pre-populates the dedup store so pre-existing content never triggers a \"new item\" Discord notification.
- Adds a daily background prune scan that removes dedup keys for items deleted from Jellyfin, preventing unbounded growth. Surviving keys have their TTL refreshed daily so suppression never lapses.
- Adds a \"Re-Seed Library\" button in the dashboard to manually re-run the seed scan.
- All scans abort on incomplete Jellyfin fetches (network errors, malformed responses) rather than acting on partial data. Concurrent seed/prune runs are blocked via a shared single-flight flag.
- Quota errors from Jellyseerr are now surfaced to the user directly (e.g. "Series Quota exceeded.") instead of a generic "An error occurred." — applies to /request, the request button, and the daily pick button.
- Auto-Map and Sync with Seerr now handle the discordIds array format introduced in Jellyseerr v3.3.0, alongside the legacy discordId string.
- form-data bumped to 4.0.6 (GHSA-hmw2-7cc7-3qxx).
