### PR TITLE
chore: bump dev to 1.5.6, split changelog from released 1.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.5.5] - 2026-04-27
-
-### 🌍 Added
-
-- **French translation (`fr`)**: Anchorr is now fully translated into French, covering all bot messages and UI text.
+## [1.5.6] - 2026-06-14
 
 ### ✨ Added
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anchorr",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "main": "app.js",
   "scripts": {
     "start": "node app.js",


### PR DESCRIPTION
## Summary
- French translation has been released separately to `main` as part of 1.5.5 (PR #118), so it's removed from the unreleased entry here to avoid duplication
- Remaining unreleased changes (overview toggle, weekly roundup) now form the 1.5.6 entry
- `package.json` bumped to 1.5.6 to match