### PR TITLE
fix(deps): pin undici to ^6.26.1 (4 CVEs)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1833,9 +1833,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
-      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "ws": "^8.18.0"
   },
   "overrides": {
-    "follow-redirects": "^1.16.0"
+    "follow-redirects": "^1.16.0",
+    "undici": "^6.26.1"
   }
 }


### PR DESCRIPTION
## Summary

- Pins `undici` to `^6.26.1` via `overrides` in `package.json` to resolve 4 vulnerabilities introduced through `discord.js`'s transitive dependency on `undici <=6.26.0`.
- `discord.js@14.26.4` (latest) still ships `undici@6.24.1` — a direct upgrade is not possible without a breaking discord.js major version change, so the override approach is used (same pattern as the existing `follow-redirects` pin).
- `npm audit --audit-level=high` passes with 0 vulnerabilities after this change.

**CVEs addressed:**
- GHSA-p88m-4jfj-68fv — HTTP header injection via Set-Cookie percent-decoding
- GHSA-vxpw-j846-p89q — WebSocket DoS via fragment count bypass
- GHSA-35p6-xmwp-9g52 — HTTP response queue poisoning via keep-alive socket reuse
- GHSA-g8m3-5g58-fq7m — Set-Cookie SameSite attribute downgrade

Docs were AI-assisted; all changes manually reviewed and verified.