### PR TITLE
fix(jellyfin): support Jellyfin 12 authorization

### DIFF
--- a/api/jellyfin.js
+++ b/api/jellyfin.js
@@ -1,5 +1,30 @@
 import axios from "axios";
+import { createRequire } from "module";
 import logger from "../utils/logger.js";
+
+const require = createRequire(import.meta.url);
+const APP_VERSION = require("../package.json").version || "0.0.0";
+
+// Jellyfin 12 disables legacy authorization by default, which kills the old
+// X-MediaBrowser-Token header. The standard Authorization header with the
+// MediaBrowser scheme works on 10.10.x and 12.x alike.
+export function jellyfinAuthHeaders(apiKey) {
+  const key = String(apiKey ?? "").trim();
+  if (!key) {
+    throw new Error("Jellyfin API key is missing - cannot build an Authorization header");
+  }
+  // Quotes, commas and control chars would break the header's own syntax.
+  // Stripping them silently would send a wrong token and surface as a generic
+  // 401, so reject instead and name the real problem.
+  if (/["'\\,\x00-\x1f\x7f]/.test(key)) {
+    throw new Error(
+      "Jellyfin API key contains characters that are invalid in an Authorization header (quotes, comma, backslash or control characters)"
+    );
+  }
+  return {
+    Authorization: `MediaBrowser Client="Anchorr", Device="Anchorr", DeviceId="anchorr-bot", Version="${APP_VERSION}", Token="${key}"`,
+  };
+}
 
 /**
  * Fetch all libraries from Jellyfin
@@ -14,7 +39,7 @@ export async function fetchLibraries(apiKey, baseUrl) {
     safeBase.pathname = basePathNoSlash + "/Library/VirtualFolders";
     const url = safeBase.href;
     const response = await axios.get(url, {
-      headers: { "X-MediaBrowser-Token": apiKey },
+      headers: jellyfinAuthHeaders(apiKey),
       timeout: 5000,
     });
 
@@ -32,7 +57,7 @@ export async function fetchLibraries(apiKey, baseUrl) {
         itemsUrlObj.pathname = basePathNoSlash + "/Items";
         const itemsUrl = itemsUrlObj.href;
         const itemsResponse = await axios.get(itemsUrl, {
-          headers: { "X-MediaBrowser-Token": apiKey },
+          headers: jellyfinAuthHeaders(apiKey),
           params: {
             Ids: vf.ItemId,
             Fields: "Path,LibraryOptions",
@@ -107,7 +132,7 @@ export async function findItemByTmdbId(tmdbId, mediaType, apiKey, baseUrl) {
     safeBase.pathname = safeBase.pathname.replace(/\/$/, "") + "/Items";
     const url = safeBase.href;
     const response = await axios.get(url, {
-      headers: { "X-MediaBrowser-Token": apiKey },
+      headers: jellyfinAuthHeaders(apiKey),
       params: {
         Recursive: true,
         AnyProviderIdEquals: `Tmdb.${tmdbId}`,
@@ -156,7 +181,7 @@ export async function findLibraryByAncestors(
     )}/Items/${itemId}/Ancestors`;
 
     const response = await axios.get(ancestorsUrl, {
-      headers: { "X-MediaBrowser-Token": apiKey },
+      headers: jellyfinAuthHeaders(apiKey),
       timeout: 5000,
     });
 
@@ -235,7 +260,7 @@ export async function findLibraryByAncestors(
         try {
           const libItemsUrl = `${baseUrl.replace(/\/$/, "")}/Items`;
           const libResponse = await axios.get(libItemsUrl, {
-            headers: { "X-MediaBrowser-Token": apiKey },
+            headers: jellyfinAuthHeaders(apiKey),
             params: {
               ParentId: library.ItemId,
               Recursive: true,
@@ -294,7 +319,7 @@ export async function findLibraryId(
     // Use the /Items endpoint without userId to avoid 400 errors
     const url = `${baseUrl.replace(/\/$/, "")}/Items`;
     const response = await axios.get(url, {
-      headers: { "X-MediaBrowser-Token": apiKey },
+      headers: jellyfinAuthHeaders(apiKey),
       params: {
         Ids: itemId,
         Fields: "ParentId,Path", // Request Path to help identify library
@@ -367,7 +392,7 @@ export async function findLibraryId(
       for (const [collectionId, library] of libraryMap.entries()) {
         try {
           const libResponse = await axios.get(url, {
-            headers: { "X-MediaBrowser-Token": apiKey },
+            headers: jellyfinAuthHeaders(apiKey),
             params: { Ids: library.ItemId, Fields: "ParentId" },
             timeout: 5000,
           });
@@ -455,7 +480,7 @@ export async function fetchRecentlyAdded(
 
     if (!minDateCreated) {
       const response = await axios.get(url, {
-        headers: { "X-MediaBrowser-Token": apiKey },
+        headers: jellyfinAuthHeaders(apiKey),
         params: baseParams,
         timeout: 10000,
       });
@@ -477,7 +502,7 @@ export async function fetchRecentlyAdded(
       let page;
       try {
         const response = await axios.get(url, {
-          headers: { "X-MediaBrowser-Token": apiKey },
+          headers: jellyfinAuthHeaders(apiKey),
           params,
           timeout: 10000,
         });
@@ -583,7 +608,7 @@ export async function fetchAllLibraryItems(apiKey, baseUrl, parentId) {
     let page;
     try {
       const response = await axios.get(url, {
-        headers: { "X-MediaBrowser-Token": apiKey },
+        headers: jellyfinAuthHeaders(apiKey),
         params,
         timeout: 15000,
       });
@@ -627,7 +652,7 @@ export async function fetchItemDetails(itemId, apiKey, baseUrl) {
   try {
     const url = `${baseUrl.replace(/\/$/, "")}/Items/${itemId}`;
     const response = await axios.get(url, {
-      headers: { "X-MediaBrowser-Token": apiKey },
+      headers: jellyfinAuthHeaders(apiKey),
       timeout: 5000,
     });
 

--- a/jellyfinPoller.js
+++ b/jellyfinPoller.js
@@ -219,7 +219,7 @@ class JellyfinPoller {
       // Cleanup old deduplicator entries
       deduplicator.cleanup();
     } catch (err) {
-      logger.error("Error during Jellyfin polling:", err);
+      logger.error(`Error during Jellyfin polling: ${err?.message || err}`);
     }
   }
 }

--- a/jellyfinWebSocket.js
+++ b/jellyfinWebSocket.js
@@ -68,7 +68,7 @@ export class JellyfinWebSocketClient {
         .replace(/\/$/, "");
 
       const deviceId = "anchorr-bot";
-      const fullUrl = `${wsUrl}/socket?api_key=${apiKey}&deviceId=${deviceId}`;
+      const fullUrl = `${wsUrl}/socket?ApiKey=${encodeURIComponent(apiKey)}&deviceId=${deviceId}`;
 
       logger.info(`🔌 Connecting to Jellyfin WebSocket: ${wsUrl}/socket`);
       logger.debug(`   Base URL: ${baseUrl}`);
@@ -105,6 +105,11 @@ export class JellyfinWebSocketClient {
       this.ws.on("error", (err) => {
         logger.error("Jellyfin WebSocket error:", err?.message || err);
         if (err?.code) logger.error("Error code:", err.code);
+        if (/Unexpected server response: (401|403)/.test(err?.message || "")) {
+          logger.error(
+            "Jellyfin rejected the WebSocket API key. On Jellyfin 12 the legacy 'api_key' parameter is disabled - check JELLYFIN_API_KEY in the dashboard."
+          );
+        }
       });
 
       this.ws.on("close", (code, reason) => {
@@ -128,6 +133,12 @@ export class JellyfinWebSocketClient {
         };
         const codeDescription = closeCodeMap[code] || "Unknown code";
         logger.warn(`   Code: ${code} (${codeDescription})`);
+
+        if (code === 1008) {
+          logger.error(
+            "Jellyfin closed the WebSocket with a policy violation - this is usually a rejected API key. Check JELLYFIN_API_KEY in the dashboard."
+          );
+        }
 
         this.isConnected = false;
 

--- a/routes/jellyfinRoutes.js
+++ b/routes/jellyfinRoutes.js
@@ -4,6 +4,7 @@ import { authenticateToken } from "../utils/auth.js";
 import { isMaskedValue } from "../utils/configSanitize.js";
 import { TIMEOUTS } from "../lib/constants.js";
 import { libraryCache } from "../jellyfinWebhook.js";
+import { jellyfinAuthHeaders } from "../api/jellyfin.js";
 import logger from "../utils/logger.js";
 import { seedLibrary, checkSeedPreconditions } from "../jellyfin/librarySeeder.js";
 import { updateConfig } from "../utils/configFile.js";
@@ -87,7 +88,7 @@ router.post("/jellyfin-libraries", authenticateToken, async (req, res) => {
     const response = await axios.get(
       safeUrl.href,
       {
-        headers: { "X-MediaBrowser-Token": apiKey },
+        headers: jellyfinAuthHeaders(apiKey),
         timeout: TIMEOUTS.JELLYFIN_API,
       }
     );
@@ -106,7 +107,7 @@ router.post("/jellyfin-libraries", authenticateToken, async (req, res) => {
 
     res.json({ success: true, libraries });
   } catch (err) {
-    logger.error("[JELLYFIN LIBRARIES API] Error:", err);
+    logger.error(`[JELLYFIN LIBRARIES API] Error: ${err?.message || err}`);
     res.status(500).json({ success: false, message: err.message });
   }
 });
@@ -166,7 +167,7 @@ router.get("/jellyfin/libraries", authenticateToken, async (req, res) => {
       })),
     });
   } catch (error) {
-    logger.error("Failed to fetch Jellyfin libraries:", error);
+    logger.error(`Failed to fetch Jellyfin libraries: ${error?.message || error}`);
     res.status(500).json({
       success: false,
       message: "Failed to fetch libraries. Check Jellyfin configuration.",


### PR DESCRIPTION
## Problem

Jellyfin 12.0 disables legacy authorization by default, and a migration turns it off on existing installs as well. `AuthorizationContext.cs` now gates the old paths behind `EnableLegacyAuthorization`:

- `X-MediaBrowser-Token` header — gated, no longer read
- `api_key` query parameter — gated, no longer read
- `Authorization: MediaBrowser …` header — always read
- `ApiKey` query parameter — always read

Anchorr used the first two exclusively, so every Jellyfin request returned 401 after upgrading. Reported as:

```
error: Request failed with status code 401
    at async routes/jellyfinRoutes.js:87:22
```

The WebSocket handshake goes through the same `AuthorizationContext` (`WebSocketManager.WebSocketRequestHandler` calls `_authService.Authenticate`), so it was affected too.

## Fix

- New shared `jellyfinAuthHeaders()` helper in `api/jellyfin.js` emitting `Authorization: MediaBrowser Client="Anchorr", …, Token="…"`. All 11 call sites converted, plus the one in `routes/jellyfinRoutes.js`. The poller, webhook, seeder, pruner, resolver and weekly roundup all route through `api/jellyfin.js` and inherit the change.
- WebSocket handshake moved from `?api_key=` to `?ApiKey=`, with the key URL-encoded. An unencoded key containing `&` or `#` could previously truncate or append query parameters.
- Both forms are accepted by 10.10.7 and 12.0, so no version switch is required and older servers keep working.

Hardening picked up while reviewing the change:

- The helper rejects a missing or malformed API key rather than emitting a well-formed header carrying an empty or mangled token. Silently stripping illegal characters would send a *different* token and surface as an indistinguishable 401. The key is trimmed first, so a value pasted with a trailing newline still works.
- WebSocket auth rejections (401/403 handshake, close code 1008) now log the actual cause instead of looping on reconnect with a generic transport error.
- Raw axios errors are no longer passed to the logger on the Jellyfin paths. The serialized error includes `config.headers`, which wrote the `Authorization` header to `logs/` in cleartext. This predates the change (it leaked `X-MediaBrowser-Token` the same way) but is fixed here since this PR introduces the new header. Affected: `routes/jellyfinRoutes.js` (2x), `jellyfinPoller.js`.

## Verification

- Outgoing request captured against a local HTTP server: the `Authorization` header is emitted correctly and no `X-MediaBrowser-Token` is sent.
- Helper edge cases exercised: empty, `undefined`, whitespace-padded, quote, comma, backslash, NUL, tab, DEL, CRLF.
- Confirmed a token no longer reaches `logs/` after the logger change.

Not tested against a live Jellyfin 12 instance.

## Out of scope

- The reconnect loop still retries indefinitely on auth failures; it only logs the cause now.
- The silent `CollectionId` fallback in `fetchLibraries` can route items to the wrong Discord channel when Jellyfin rejects `/Items`. Pre-existing, worth its own issue.
- The `logger.error("...", err)` pattern exists at roughly 20 other call sites. Only the Jellyfin paths were touched, since only those carry an auth header.