### PR TITLE
fix(jellyfin): support Jellyfin 12 authorization (v1.6.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.6.1] - 2026-09-11
+
+### 🐛 Fixed
+
+- **Jellyfin 12 compatibility**: Jellyfin 12.0 disables legacy authorization by default, and its migration turns it off on existing installs as well. Anchorr authenticated exclusively via the now-disabled `X-MediaBrowser-Token` header and `api_key` query parameter, so every Jellyfin request failed with `401` after upgrading: no notifications, no library list in the dashboard, no WebSocket connection. All Jellyfin calls now use the standard `Authorization: MediaBrowser` header, and the WebSocket handshake uses the `ApiKey` query parameter. Both are accepted by Jellyfin 10.10.x and 12.x, so older servers keep working and no configuration change is needed.
+- **Invalid Jellyfin API key now reported directly**: A missing or malformed API key previously produced a valid-looking request that Jellyfin answered with a generic `401`, making a config mistake indistinguishable from a server problem. The key is now validated before the request and the actual reason is logged.
+- **Jellyfin WebSocket auth failures are no longer silent**: A rejected API key surfaced only as a generic transport error inside an endless reconnect loop. Authorization rejections now log the real cause.
+
+### 🔒 Security
+
+- **Jellyfin auth header no longer written to log files**: Passing a raw axios error to the logger serialized the request configuration, including the `Authorization` header, into `logs/combined-*.log` and `logs/error-*.log` in cleartext. The affected Jellyfin code paths now log only the error message. Existing log files are not rewritten. If you have been running Anchorr with debug logs retained, rotate or delete `logs/` and regenerate your Jellyfin API key.
+
+---
+
 ## [1.6.0] - 2026-09-02
 
 ### ✨ Added

--- a/api/jellyfin.js
+++ b/api/jellyfin.js
@@ -1,5 +1,30 @@
 import axios from "axios";
+import { createRequire } from "module";
 import logger from "../utils/logger.js";
+
+const require = createRequire(import.meta.url);
+const APP_VERSION = require("../package.json").version || "0.0.0";
+
+// Jellyfin 12 disables legacy authorization by default, which kills the old
+// X-MediaBrowser-Token header. The standard Authorization header with the
+// MediaBrowser scheme works on 10.10.x and 12.x alike.
+export function jellyfinAuthHeaders(apiKey) {
+  const key = String(apiKey ?? "").trim();
+  if (!key) {
+    throw new Error("Jellyfin API key is missing - cannot build an Authorization header");
+  }
+  // Quotes, commas and control chars would break the header's own syntax.
+  // Stripping them silently would send a wrong token and surface as a generic
+  // 401, so reject instead and name the real problem.
+  if (/["'\\,\x00-\x1f\x7f]/.test(key)) {
+    throw new Error(
+      "Jellyfin API key contains characters that are invalid in an Authorization header (quotes, comma, backslash or control characters)"
+    );
+  }
+  return {
+    Authorization: `MediaBrowser Client="Anchorr", Device="Anchorr", DeviceId="anchorr-bot", Version="${APP_VERSION}", Token="${key}"`,
+  };
+}
 
 /**
  * Fetch all libraries from Jellyfin
@@ -14,7 +39,7 @@ export async function fetchLibraries(apiKey, baseUrl) {
     safeBase.pathname = basePathNoSlash + "/Library/VirtualFolders";
     const url = safeBase.href;
     const response = await axios.get(url, {
-      headers: { "X-MediaBrowser-Token": apiKey },
+      headers: jellyfinAuthHeaders(apiKey),
       timeout: 5000,
     });
 
@@ -32,7 +57,7 @@ export async function fetchLibraries(apiKey, baseUrl) {
         itemsUrlObj.pathname = basePathNoSlash + "/Items";
         const itemsUrl = itemsUrlObj.href;
         const itemsResponse = await axios.get(itemsUrl, {
-          headers: { "X-MediaBrowser-Token": apiKey },
+          headers: jellyfinAuthHeaders(apiKey),
           params: {
             Ids: vf.ItemId,
             Fields: "Path,LibraryOptions",
@@ -107,7 +132,7 @@ export async function findItemByTmdbId(tmdbId, mediaType, apiKey, baseUrl) {
     safeBase.pathname = safeBase.pathname.replace(/\/$/, "") + "/Items";
     const url = safeBase.href;
     const response = await axios.get(url, {
-      headers: { "X-MediaBrowser-Token": apiKey },
+      headers: jellyfinAuthHeaders(apiKey),
       params: {
         Recursive: true,
         AnyProviderIdEquals: `Tmdb.${tmdbId}`,
@@ -156,7 +181,7 @@ export async function findLibraryByAncestors(
     )}/Items/${itemId}/Ancestors`;
 
     const response = await axios.get(ancestorsUrl, {
-      headers: { "X-MediaBrowser-Token": apiKey },
+      headers: jellyfinAuthHeaders(apiKey),
       timeout: 5000,
     });
 
@@ -235,7 +260,7 @@ export async function findLibraryByAncestors(
         try {
           const libItemsUrl = `${baseUrl.replace(/\/$/, "")}/Items`;
           const libResponse = await axios.get(libItemsUrl, {
-            headers: { "X-MediaBrowser-Token": apiKey },
+            headers: jellyfinAuthHeaders(apiKey),
             params: {
               ParentId: library.ItemId,
               Recursive: true,
@@ -294,7 +319,7 @@ export async function findLibraryId(
     // Use the /Items endpoint without userId to avoid 400 errors
     const url = `${baseUrl.replace(/\/$/, "")}/Items`;
     const response = await axios.get(url, {
-      headers: { "X-MediaBrowser-Token": apiKey },
+      headers: jellyfinAuthHeaders(apiKey),
       params: {
         Ids: itemId,
         Fields: "ParentId,Path", // Request Path to help identify library
@@ -367,7 +392,7 @@ export async function findLibraryId(
       for (const [collectionId, library] of libraryMap.entries()) {
         try {
           const libResponse = await axios.get(url, {
-            headers: { "X-MediaBrowser-Token": apiKey },
+            headers: jellyfinAuthHeaders(apiKey),
             params: { Ids: library.ItemId, Fields: "ParentId" },
             timeout: 5000,
           });
@@ -455,7 +480,7 @@ export async function fetchRecentlyAdded(
 
     if (!minDateCreated) {
       const response = await axios.get(url, {
-        headers: { "X-MediaBrowser-Token": apiKey },
+        headers: jellyfinAuthHeaders(apiKey),
         params: baseParams,
         timeout: 10000,
       });
@@ -477,7 +502,7 @@ export async function fetchRecentlyAdded(
       let page;
       try {
         const response = await axios.get(url, {
-          headers: { "X-MediaBrowser-Token": apiKey },
+          headers: jellyfinAuthHeaders(apiKey),
           params,
           timeout: 10000,
         });
@@ -583,7 +608,7 @@ export async function fetchAllLibraryItems(apiKey, baseUrl, parentId) {
     let page;
     try {
       const response = await axios.get(url, {
-        headers: { "X-MediaBrowser-Token": apiKey },
+        headers: jellyfinAuthHeaders(apiKey),
         params,
         timeout: 15000,
       });
@@ -627,7 +652,7 @@ export async function fetchItemDetails(itemId, apiKey, baseUrl) {
   try {
     const url = `${baseUrl.replace(/\/$/, "")}/Items/${itemId}`;
     const response = await axios.get(url, {
-      headers: { "X-MediaBrowser-Token": apiKey },
+      headers: jellyfinAuthHeaders(apiKey),
       timeout: 5000,
     });
 

--- a/jellyfinPoller.js
+++ b/jellyfinPoller.js
@@ -219,7 +219,7 @@ class JellyfinPoller {
       // Cleanup old deduplicator entries
       deduplicator.cleanup();
     } catch (err) {
-      logger.error("Error during Jellyfin polling:", err);
+      logger.error(`Error during Jellyfin polling: ${err?.message || err}`);
     }
   }
 }

--- a/jellyfinWebSocket.js
+++ b/jellyfinWebSocket.js
@@ -68,7 +68,7 @@ export class JellyfinWebSocketClient {
         .replace(/\/$/, "");
 
       const deviceId = "anchorr-bot";
-      const fullUrl = `${wsUrl}/socket?api_key=${apiKey}&deviceId=${deviceId}`;
+      const fullUrl = `${wsUrl}/socket?ApiKey=${encodeURIComponent(apiKey)}&deviceId=${deviceId}`;
 
       logger.info(`🔌 Connecting to Jellyfin WebSocket: ${wsUrl}/socket`);
       logger.debug(`   Base URL: ${baseUrl}`);
@@ -105,6 +105,11 @@ export class JellyfinWebSocketClient {
       this.ws.on("error", (err) => {
         logger.error("Jellyfin WebSocket error:", err?.message || err);
         if (err?.code) logger.error("Error code:", err.code);
+        if (/Unexpected server response: (401|403)/.test(err?.message || "")) {
+          logger.error(
+            "Jellyfin rejected the WebSocket API key. On Jellyfin 12 the legacy 'api_key' parameter is disabled - check JELLYFIN_API_KEY in the dashboard."
+          );
+        }
       });
 
       this.ws.on("close", (code, reason) => {
@@ -128,6 +133,12 @@ export class JellyfinWebSocketClient {
         };
         const codeDescription = closeCodeMap[code] || "Unknown code";
         logger.warn(`   Code: ${code} (${codeDescription})`);
+
+        if (code === 1008) {
+          logger.error(
+            "Jellyfin closed the WebSocket with a policy violation - this is usually a rejected API key. Check JELLYFIN_API_KEY in the dashboard."
+          );
+        }
 
         this.isConnected = false;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "anchorr",
-  "version": "1.5.6",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "anchorr",
-      "version": "1.5.6",
+      "version": "1.6.1",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anchorr",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "main": "app.js",
   "scripts": {
     "start": "node app.js",

--- a/routes/jellyfinRoutes.js
+++ b/routes/jellyfinRoutes.js
@@ -4,6 +4,7 @@ import { authenticateToken } from "../utils/auth.js";
 import { isMaskedValue } from "../utils/configSanitize.js";
 import { TIMEOUTS } from "../lib/constants.js";
 import { libraryCache } from "../jellyfinWebhook.js";
+import { jellyfinAuthHeaders } from "../api/jellyfin.js";
 import logger from "../utils/logger.js";
 import { seedLibrary, checkSeedPreconditions } from "../jellyfin/librarySeeder.js";
 import { updateConfig } from "../utils/configFile.js";
@@ -87,7 +88,7 @@ router.post("/jellyfin-libraries", authenticateToken, async (req, res) => {
     const response = await axios.get(
       safeUrl.href,
       {
-        headers: { "X-MediaBrowser-Token": apiKey },
+        headers: jellyfinAuthHeaders(apiKey),
         timeout: TIMEOUTS.JELLYFIN_API,
       }
     );
@@ -106,7 +107,7 @@ router.post("/jellyfin-libraries", authenticateToken, async (req, res) => {
 
     res.json({ success: true, libraries });
   } catch (err) {
-    logger.error("[JELLYFIN LIBRARIES API] Error:", err);
+    logger.error(`[JELLYFIN LIBRARIES API] Error: ${err?.message || err}`);
     res.status(500).json({ success: false, message: err.message });
   }
 });
@@ -166,7 +167,7 @@ router.get("/jellyfin/libraries", authenticateToken, async (req, res) => {
       })),
     });
   } catch (error) {
-    logger.error("Failed to fetch Jellyfin libraries:", error);
+    logger.error(`Failed to fetch Jellyfin libraries: ${error?.message || error}`);
     res.status(500).json({
       success: false,
       message: "Failed to fetch libraries. Check Jellyfin configuration.",


### PR DESCRIPTION
## Problem

Jellyfin 12.0 disables legacy authorization by default, and its migration turns it off on existing installs too. Anchorr authenticated only via `X-MediaBrowser-Token` and the `api_key` query parameter, so every Jellyfin request returned `401` after upgrading: no notifications, no library list, no WebSocket.

## Fix

- All Jellyfin calls use the standard `Authorization: MediaBrowser` header, the WebSocket handshake uses `ApiKey`. Both work on 10.10.x and 12.x, so no config change is needed.
- A missing or malformed API key is rejected before the request instead of producing another indistinguishable `401`.
- WebSocket auth rejections log the real cause instead of looping silently on reconnect.
- Raw axios errors are no longer passed to the logger on Jellyfin paths, where the serialized `config.headers` wrote the auth header into `logs/` in cleartext.